### PR TITLE
Implement URL shortcut service

### DIFF
--- a/shortcutter/apps.py
+++ b/shortcutter/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class ShortcutterConfig(AppConfig):
+    name = 'shortcutter'

--- a/shortcutter/models.py
+++ b/shortcutter/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here.

--- a/shortcutter/tests.py
+++ b/shortcutter/tests.py
@@ -1,0 +1,26 @@
+import pytest
+from django.test import Client
+from django.core.urlresolvers import reverse
+from django.test.utils import override_settings
+
+
+@pytest.fixture
+def client():
+    return Client()
+
+
+@override_settings(SHORTCUTTER_UNIT_URL='https://example.com/unit/{id}')
+@pytest.mark.django_db
+def test_unit_short_url(client):
+    url = reverse('shortcutter-unit-url', kwargs=dict(unit_id=1234))
+    resp = client.get(url)
+    assert resp.status_code == 302
+    assert resp.url == 'https://example.com/unit/1234'
+
+
+@override_settings(SHORTCUTTER_UNIT_URL=None)
+@pytest.mark.django_db
+def test_unit_short_url_no_config(client):
+    url = reverse('shortcutter-unit-url', kwargs=dict(unit_id=1234))
+    resp = client.get(url)
+    assert resp.status_code == 501

--- a/shortcutter/urls.py
+++ b/shortcutter/urls.py
@@ -1,0 +1,7 @@
+from django.conf.urls import url
+from . import views
+
+
+urlpatterns = [
+    url(r'^tp(?P<unit_id>[0-9]+)/?$', views.unit_short_url, name='shortcutter-unit-url'),
+]

--- a/shortcutter/views.py
+++ b/shortcutter/views.py
@@ -1,0 +1,15 @@
+from django.shortcuts import redirect
+from django.conf import settings
+from django.http.response import HttpResponse
+
+
+class HttpResponseNotImplemented(HttpResponse):
+    status_code = 501
+
+
+def unit_short_url(request, unit_id):
+    unit_url = getattr(settings, 'SHORTCUTTER_UNIT_URL', None)
+    if not unit_url:
+        return HttpResponseNotImplemented()
+
+    return redirect(unit_url.format(id=unit_id))

--- a/smbackend/urls.py
+++ b/smbackend/urls.py
@@ -6,6 +6,7 @@ from services.unit_redirect_viewset import UnitRedirectViewSet
 from rest_framework import routers
 #from observations.views import obtain_auth_token
 from munigeo.api import all_views as munigeo_views
+from shortcutter import urls as shortcutter_urls
 
 from services import views
 
@@ -36,5 +37,6 @@ urlpatterns = [
     url(r'^open311/', views.post_service_request, name='services'),
     url(r'^v2/', include(router.urls)),
     #url(r'^v2/api-token-auth/', obtain_auth_token, name='api-auth-token'),
-    url(r'^v2/redirect/unit/', UnitRedirectViewSet.as_view({'get': 'list'}))
+    url(r'^v2/redirect/unit/', UnitRedirectViewSet.as_view({'get': 'list'})),
+    url(r'', include(shortcutter_urls)),
 ]


### PR DESCRIPTION
Project settings should have a SHORTCUTTER_UNIT_URL that points
to where the short URL service should redirect. The string must
include "{id}" which is replaced by the unit id.