### PR TITLE
Add many more addresses by upgrading django-munigeo to v0.2.10

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ django-filter
 django-modeltranslation
 requests
 requests_cache
--e git+https://github.com/City-of-Helsinki/munigeo#egg=django-munigeo
+-e git+https://github.com/City-of-Helsinki/django-munigeo@v0.2.10#egg=django-munigeo
 pytz
 django-cors-headers
 django-extensions

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,15 +4,15 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
--e git+https://github.com/City-of-Helsinki/munigeo@v0.2.9#egg=django_munigeo-master
+-e git+https://github.com/City-of-Helsinki/django-munigeo@v0.2.10#egg=django-munigeo
+certifi==2018.10.15       # via requests
+chardet==3.0.4            # via requests
 click==6.7                # via pip-tools
 django-cors-headers==1.1.0
 django-extensions==1.7.8
 django-filter==1.0.2
 django-haystack==2.6.1
 django-modeltranslation==0.12.1
-django-modeltranslation==0.12.1
-django-mptt==0.8.7
 django-mptt==0.8.7
 django-polymorphic==1.0.2
 django==1.11.15
@@ -21,6 +21,7 @@ djangorestframework==3.6.3
 elasticsearch==1.9.0
 first==2.0.1              # via pip-tools
 hypothesis==3.19.3
+idna==2.6                 # via requests
 lxml==3.4.4
 markdown==2.6.2
 pip-tools==1.8.0
@@ -36,4 +37,4 @@ requests-cache==0.4.13
 requests-mock==1.3.0
 requests==2.18.4
 six==1.9.0                # via django-extensions, pip-tools, python-dateutil, requests-mock
-urllib3==1.22             # via elasticsearch
+urllib3==1.22             # via elasticsearch, requests


### PR DESCRIPTION
Upgrading Django munigeo to version v0.2.10 will many road-like features
to the street and address endpoints. Especially this will add alleys
that were previously missing.

As this was done with pip-compile, some transitive dependencies were
also added to requirements.txt