### PR TITLE
Fix elastic and django out-of sync problem with non-public units

### DIFF
--- a/services/api.py
+++ b/services/api.py
@@ -1049,6 +1049,10 @@ class SearchViewSet(munigeo_api.GeoModelAPIView, viewsets.ViewSetMixin, generics
             services = service.split(',')
             queryset = queryset.filter(django_ct='services.unit').filter(services__in=services)
 
+        # Only units marked public should be returned. For other types,
+        # public is always True.
+        queryset = queryset.filter(public=True)
+
         models = set()
         types = request.query_params.get('type', '').split(',')
         for t in types:

--- a/services/models/unit.py
+++ b/services/models/unit.py
@@ -84,7 +84,7 @@ class UnitSearchManager(models.GeoManager):
             for f in self.include_fields:
                 if f in unit_related_fields:
                     qs = qs.prefetch_related(f)
-        return qs.filter(public=True)
+        return qs
 
 
 class Unit(models.Model):

--- a/services/search_indexes.py
+++ b/services/search_indexes.py
@@ -36,6 +36,7 @@ class ServiceMapBaseIndex(indexes.SearchIndex, indexes.Indexable):
     autosuggest_exact = indexes.CharField(model_attr='name', boost=1.125)
     extra_searchwords = indexes.CharField()
     autosuggest_extra_searchwords = indexes.CharField()
+    public = indexes.BooleanField()
 
     def __init__(self, *args, **kwargs):
         super(*args, **kwargs)
@@ -46,6 +47,9 @@ class ServiceMapBaseIndex(indexes.SearchIndex, indexes.Indexable):
 
     def get_updated_field(self):
         return 'last_modified_time'
+
+    def prepare_public(self, obj):
+        return True
 
     def _prepare_extra_searchwords(self, obj):
         return ' '.join([category.name for category in obj.keywords.filter(language=get_language())])
@@ -68,6 +72,9 @@ class UnitIndex(ServiceMapBaseIndex):
     def __init__(self, *args, **kwargs):
         super(*args, **kwargs)
         self.model = apps.get_model(app_label='services', model_name='Unit')
+
+    def prepare_public(self, obj):
+        return obj.public
 
     def prepare_services(self, obj):
         return [ow.id for ow in obj.services.all()]


### PR DESCRIPTION
The filtering out of public==False units was done in the
wrong place. Fix: index the public field and filter using
SearchQueryset.