### PR TITLE
Feature/search results sorting

### DIFF
--- a/services/search_indexes.py
+++ b/services/search_indexes.py
@@ -33,6 +33,8 @@ class DeleteOnlySignalProcessor(signals.BaseSignalProcessor):
 
 class ServiceMapBaseIndex(indexes.SearchIndex, indexes.Indexable):
     text = indexes.CharField(document=True, use_template=True)
+    name = indexes.CharField(model_attr='name', boost=1.125)
+    name_sort = indexes.CharField(model_attr='name')
     autosuggest = indexes.EdgeNgramField(model_attr='name')
     autosuggest_exact = indexes.CharField(model_attr='name', boost=1.125)
     extra_searchwords = indexes.CharField()

--- a/services/templates/search/indexes/services/service_text.txt
+++ b/services/templates/search/indexes/services/service_text.txt
@@ -1,1 +1,1 @@
-{{object.name}}
+

--- a/services/templates/search/indexes/services/servicenode_text.txt
+++ b/services/templates/search/indexes/services/servicenode_text.txt
@@ -1,1 +1,1 @@
-{{object.name}}
+

--- a/services/templates/search/indexes/services/unit_text.txt
+++ b/services/templates/search/indexes/services/unit_text.txt
@@ -1,4 +1,3 @@
-{{object.name}}
 {{object.service_names}}
 {{object.highlight_names}}
 {% if object.municipality %}{{object.municipality.name}}{% endif %}

--- a/smbackend/elasticsearch/mappings_finnish.json
+++ b/smbackend/elasticsearch/mappings_finnish.json
@@ -7,11 +7,21 @@
                 "index_analyzer": "edgengram_analyzer",
                 "analyzer": null
             },
+            "name_sort": {
+              "type": "string",
+              "index": "not_analyzed"
+            },
             "autosuggest_exact": {
                 "type": "string",
                 "search_quote_analyzer": "autosuggest_exact_query",
                 "search_analyzer": "autosuggest_exact_query",
                 "index_analyzer": "autosuggest_exact",
+                "analyzer": null
+            },
+            "name": {
+                "type": "string",
+                "index_analyzer": "fulltext_index",
+                "search_analyzer": "fulltext_query",
                 "analyzer": null
             },
             "text": {


### PR DESCRIPTION
There are two changes in this PR.

The first one stores an additional field in the search index to allow
sorting by unanalyzed name in addition to score. This sorting is also
taken into use.

The second one creates a separate field for name in order to
boost name matches compared to text template matches.