### PR TITLE
Fix bug in ORM layer database optimizations

### DIFF
--- a/services/api.py
+++ b/services/api.py
@@ -63,10 +63,6 @@ def register_view(klass, name, basename=None):
         serializers_by_model[model] = klass.serializer_class
 
 
-# These are API fields which are not 1:1 simple
-# model fields and cannot be used as ORM only
-# parameters in db queries
-SPECIAL_FIELDS = {'accessibility_shortcoming_count'}
 LANGUAGES = [x[0] for x in settings.LANGUAGES]
 
 logger = logging.getLogger(__name__)
@@ -344,10 +340,9 @@ class JSONAPIViewSetMixin:
                 for field in model_fields:
                     if field.name == field_name:
                         break
-                    if field_name not in SPECIAL_FIELDS:
-                        raise ParseError("field '%s' supplied in 'only' not found" % field_name)
+                else:
+                    raise ParseError("field '%s' supplied in 'only' not found" % field_name)
             fields = self.only_fields.copy()
-            fields = [f for f in self.only_fields if f not in SPECIAL_FIELDS]
             if 'parent' in fields:
                 fields.remove('parent')
                 fields.append('parent_id')

--- a/services/api.py
+++ b/services/api.py
@@ -63,6 +63,10 @@ def register_view(klass, name, basename=None):
         serializers_by_model[model] = klass.serializer_class
 
 
+# These are API fields which are not 1:1 simple
+# model fields and cannot be used as ORM only
+# parameters in db queries
+SPECIAL_FIELDS = {'accessibility_shortcoming_count'}
 LANGUAGES = [x[0] for x in settings.LANGUAGES]
 
 logger = logging.getLogger(__name__)
@@ -340,9 +344,10 @@ class JSONAPIViewSetMixin:
                 for field in model_fields:
                     if field.name == field_name:
                         break
-                else:
-                    raise ParseError("field '%s' supplied in 'only' not found" % field_name)
+                    if field_name not in SPECIAL_FIELDS:
+                        raise ParseError("field '%s' supplied in 'only' not found" % field_name)
             fields = self.only_fields.copy()
+            fields = [f for f in self.only_fields if f not in SPECIAL_FIELDS]
             if 'parent' in fields:
                 fields.remove('parent')
                 fields.append('parent_id')

--- a/services/utils/__init__.py
+++ b/services/utils/__init__.py
@@ -1,2 +1,3 @@
 from .accessibility_shortcoming_calculator import AccessibilityShortcomingCalculator
 from .translator import get_translated
+from .models import check_valid_concrete_field

--- a/services/utils/models.py
+++ b/services/utils/models.py
@@ -1,0 +1,9 @@
+from django.core.exceptions import FieldDoesNotExist
+
+
+def check_valid_concrete_field(model, f):
+    try:
+        return model._meta.get_field(f).concrete
+    except FieldDoesNotExist:
+        return False
+    return False


### PR DESCRIPTION
There was a database optimization in use which uses the Django QuerySet only method to restrict the fields retrieved from database models according to which fields are requested through the REST API (using the 'only' query parameter there).

This mechanism was brittle, because it required that:
- fields in the API used in only parameters have a 1:1 correspondence in database columns, ie. concrete model fields

This PR simplifies the logic so that nonexisting fields are simply ignored, but they are not used in the ORM level 'only' method call because that would cause an exception 