### PR TITLE
Fix html browsable API rendering for observations endpoint

### DIFF
--- a/observations/api.py
+++ b/observations/api.py
@@ -1,6 +1,6 @@
 from rest_framework import viewsets
 from rest_framework.exceptions import AuthenticationFailed
-from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from django.utils.translation import ugettext_lazy as _
 
 from services.api import ServiceSerializer, UnitSerializer
@@ -30,11 +30,7 @@ class ObservationViewSet(JSONAPIViewSetMixin, viewsets.ModelViewSet):
         """
         Allow GETting without credentials
         """
-        if self.action in ['list', 'retrieve']:
-            permission_classes = [AllowAny]
-        else:
-            permission_classes = [IsAuthenticated]
-        return [permission() for permission in permission_classes]
+        return[IsAuthenticatedOrReadOnly()]
 
 
 class ObservableSerializerMixin:

--- a/observations/api.py
+++ b/observations/api.py
@@ -1,5 +1,6 @@
 from rest_framework import viewsets
 from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from django.utils.translation import ugettext_lazy as _
 
 from services.api import ServiceSerializer, UnitSerializer
@@ -21,7 +22,19 @@ class ObservationViewSet(JSONAPIViewSetMixin, viewsets.ModelViewSet):
         return super(ObservationViewSet, self).create(request, *args, **kwargs)
 
     def get_serializer_context(self):
-        return {'user': self.request.user, 'auth': self.request.auth}
+        context = super().get_serializer_context()
+        context.update({'user': self.request.user, 'auth': self.request.auth})
+        return context
+
+    def get_permissions(self):
+        """
+        Allow GETting without credentials
+        """
+        if self.action in ['list', 'retrieve']:
+            permission_classes = [AllowAny]
+        else:
+            permission_classes = [IsAuthenticated]
+        return [permission() for permission in permission_classes]
 
 
 class ObservableSerializerMixin:

--- a/observations/api.py
+++ b/observations/api.py
@@ -14,6 +14,7 @@ from services.api import (
 class ObservationViewSet(JSONAPIViewSetMixin, viewsets.ModelViewSet):
     queryset = models.Observation.objects.all()
     serializer_class = ObservationSerializer
+    permission_classes = [IsAuthenticatedOrReadOnly]
 
     def create(self, request, *args, **kwargs):
         if request.auth is None:
@@ -25,12 +26,6 @@ class ObservationViewSet(JSONAPIViewSetMixin, viewsets.ModelViewSet):
         context = super().get_serializer_context()
         context.update({'user': self.request.user, 'auth': self.request.auth})
         return context
-
-    def get_permissions(self):
-        """
-        Allow GETting without credentials
-        """
-        return[IsAuthenticatedOrReadOnly()]
 
 
 class ObservableSerializerMixin:


### PR DESCRIPTION
Fixed by properly announcing required permissions, causing
the html renderer not to try to create the POST form (which
caused the problem) because of lack of authentication. The
browsable API is for browsing anyway.

Also properly call super in get_serializer_context (unrelated,
should have no effects.)