### PR TITLE
Change Observation-Unit ondelete rule to CASCADE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
 script:
   - flake8
   - black --check .
-  - isort -c
+  - isort . -c
   - pytest --cov=. --hypothesis-profile=ci
 
 after_success:

--- a/observations/models.py
+++ b/observations/models.py
@@ -91,7 +91,7 @@ class Observation(PolymorphicModel):
         services_models.Unit,
         blank=False,
         null=False,
-        on_delete=models.PROTECT,
+        on_delete=models.CASCADE,
         help_text="The unit the observation is about",
         related_name="observation_history",
     )

--- a/observations/tests/test_api_write.py
+++ b/observations/tests/test_api_write.py
@@ -7,6 +7,7 @@ from rest_framework.reverse import reverse
 
 from data import observation_raw_data
 from observations.models import Observation
+from services.models import Unit
 
 
 def authenticate_user(api_client, user):
@@ -16,7 +17,6 @@ def authenticate_user(api_client, user):
     api_client.credentials(HTTP_AUTHORIZATION="Token " + token)
 
 
-# Skipping test until observations migrated to v2
 @pytest.mark.django_db
 def test__create_observation(api_client, observable_property, unit, user):
     url = (
@@ -53,7 +53,6 @@ def test__create_observation(api_client, observable_property, unit, user):
     assert Observation.objects.count() == count
 
 
-# Skipping test until observations migrated to v2
 @pytest.mark.django_db
 def test__create_descriptive_observation(api_client, descriptive_property, unit, user):
     url = (
@@ -106,3 +105,12 @@ def test__create_descriptive_observation(api_client, descriptive_property, unit,
         assert data["unit"] == raw_data["unit"]
 
     assert Observation.objects.count() == count
+
+
+@pytest.mark.django_db
+def test__delete_unit_with_observation_link(categorical_observations, unit):
+    assert Unit.objects.count() == 1
+    assert Observation.objects.count() == 4
+    unit.delete()
+    assert Unit.objects.count() == 0
+    assert Observation.objects.count() == 0

--- a/services/tests/test_services_import.py
+++ b/services/tests/test_services_import.py
@@ -286,7 +286,7 @@ def assert_service_details_correctly_imported(source, imported):
 @settings(
     suppress_health_check=[HealthCheck.too_slow],
     timeout=hypothesis.unlimited,
-    max_examples=200,
+    max_examples=100,
 )
 @given(closed_object_set())
 def test_import_units(api_client, resources):


### PR DESCRIPTION
Unit deletion fails if it has linked Observations.
Change ondelete-attribute to CASCADE to fix this.
Also add tests for this functionality.