### PR TITLE
Add live swim water temp observable property

### DIFF
--- a/observations/fixtures/initial_observable_properties_swimming.yaml
+++ b/observations/fixtures/initial_observable_properties_swimming.yaml
@@ -116,3 +116,13 @@
     description_sv: Stängd av andra skäl
     description_en: Closed for other reasons than cyanobacteria
     quality: unusable
+- model: observations.ObservableProperty
+  pk: live_swimming_water_temperature
+  fields:
+    name_fi: Veden lämpötila (sensori)
+    name_en: Water temperature (sensor)
+    name_sv: Vattentemperatur (sensor)
+    observation_type: observations.DescriptiveObservation
+    services:
+      - 731
+      - 730


### PR DESCRIPTION
Add live swimming water temperature observable property to be able to post sensor measured temperatures and separate it from manually measured temperature range and eventually show it on the outdoor sports map.