### PR TITLE
smbackend_turku: Remove unnecessary line breaks from unit description

### DIFF
--- a/smbackend_turku/importers/units.py
+++ b/smbackend_turku/importers/units.py
@@ -27,7 +27,6 @@ from smbackend_turku.importers.utils import (
     get_localized_value,
     get_turku_resource,
     get_weekday_str,
-    nl2br,
     set_syncher_object_field,
     set_syncher_tku_translated_field,
 )
@@ -298,7 +297,7 @@ class UnitImporter:
     def _handle_service_descriptions(self, obj, unit_data):
         description_data = unit_data.get("kuvaus_kieliversiot", {})
         descriptions = {
-            lang: nl2br(description_data.get(lang, "")) for lang in ("fi", "sv", "en")
+            lang: description_data.get(lang, "") for lang in ("fi", "sv", "en")
         }
         set_syncher_tku_translated_field(obj, "description", descriptions, clean=False)
 

--- a/smbackend_turku/importers/utils.py
+++ b/smbackend_turku/importers/utils.py
@@ -152,10 +152,6 @@ def postcodes():
     return _postcodes
 
 
-def nl2br(string):
-    return "<br>".join(string.splitlines())
-
-
 def get_weekday_str(index, lang="fi"):
     assert 1 <= index <= 7 and lang in ("fi", "sv", "en")
     weekdays = (


### PR DESCRIPTION
The new UI does not need this formatting and actually displays the added `<br>`s in the view in unwanted way.

<img width="396" alt="br_before" src="https://user-images.githubusercontent.com/10584178/93057685-ff6b0900-f676-11ea-93f9-b87ff500976c.png">

-> 

<img width="394" alt="br_after" src="https://user-images.githubusercontent.com/10584178/93057716-05f98080-f677-11ea-8ad2-e9ea321a0cf8.png">

