### PR TITLE
smbackend_turku: Remove service nodes without units

### DIFF
--- a/smbackend_turku/importers/units.py
+++ b/smbackend_turku/importers/units.py
@@ -114,6 +114,7 @@ class UnitImporter:
         self.unitsyncher.finish()
 
         update_service_node_counts()
+        self._remove_empty_service_nodes()
 
     def _handle_unit(self, unit_data):
         unit_id = int(unit_data["koodi"])
@@ -549,6 +550,12 @@ class UnitImporter:
                 set_syncher_tku_translated_field(obj, model_field, value)
             else:
                 set_syncher_object_field(obj, model_field, value)
+
+    def _remove_empty_service_nodes(self):
+        nodes = ServiceNode.objects.filter(unit_counts=None)
+        delete_count = nodes.count()
+        nodes.delete()
+        self.logger.info("Deleted {} service nodes without units.".format(delete_count))
 
 
 def import_units(**kwargs):

--- a/smbackend_turku/tests/data/units.json
+++ b/smbackend_turku/tests/data/units.json
@@ -193,6 +193,18 @@
                 }
             ]
         },
+        "palvelutarjoukset": [
+            {
+                "palvelut": [
+                    {
+                        "koodi": "111",
+                        "nimi_kieliversiot": {
+                            "fi": "Päiväkotitoiminta"
+                        }
+                    }
+                ]
+            }
+        ],
         "muutospvm": "2019-01-22",
         "ptv_id": "hs8790h7-h898-97h7-s9kj-86597867g978"
     }

--- a/smbackend_turku/tests/utils.py
+++ b/smbackend_turku/tests/utils.py
@@ -3,14 +3,22 @@ import os
 
 from django.conf import settings
 from django.contrib.gis.geos import Point
-from munigeo.models import Municipality
+from munigeo.models import (
+    AdministrativeDivision,
+    AdministrativeDivisionType,
+    Municipality,
+)
 
 from smbackend_turku.importers.utils import get_weekday_str
 
 
 def create_municipality():
+    division_type = AdministrativeDivisionType.objects.create(id=1, type="muni")
+    division = AdministrativeDivision.objects.create(
+        type=division_type, id=1, name_fi="Turku"
+    )
     Municipality.objects.create(
-        id="turku", name="Turku", name_fi="Turku", name_sv="Åbo"
+        id="turku", name="Turku", name_fi="Turku", name_sv="Åbo", division=division
     )
 
 


### PR DESCRIPTION
Remove service nodes that have no units so they are not listed as empty in the UI listing.
<img width="198" alt="example" src="https://user-images.githubusercontent.com/10584178/94556824-6509e880-0266-11eb-991b-4bf250411ab7.png">

In addition to testing service node removal, add also a couple of service and unit relation tests.