### PR TITLE
Add Whitenoise middleware for handling /static

### DIFF
--- a/deploy/requirements.txt
+++ b/deploy/requirements.txt
@@ -1,2 +1,0 @@
--r ../requirements.txt
-whitenoise

--- a/requirements.in
+++ b/requirements.in
@@ -31,3 +31,4 @@ isort
 pep8-naming
 jedi==0.17.2
 parso==0.7.1
+whitenoise

--- a/requirements.txt
+++ b/requirements.txt
@@ -173,6 +173,8 @@ urllib3==1.26.3
     # via
     #   elasticsearch
     #   requests
+whitenoise==5.2.0
+    # via -r requirements.in
 zipp==3.4.0
     # via importlib-metadata
 

--- a/smbackend/settings.py
+++ b/smbackend/settings.py
@@ -86,6 +86,7 @@ TURKU_API_KEY = env("TURKU_API_KEY")
 ACCESSIBILITY_SYSTEM_ID = env("ACCESSIBILITY_SYSTEM_ID")
 
 MIDDLEWARE = [
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.middleware.gzip.GZipMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",


### PR DESCRIPTION
Whitenoise allows Django to handle its own /static serving while offloading bulk of the work to WSGI server. For our Docker image this would be uWSGI. Because Django handles static files, nothing else needs to be configured to know where they are in the filesystem. Only setting needed is Djangos own STATIC_DIR.