### PR TITLE
Restart uWSGI when RSS hits 500 megabytes

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -28,4 +28,5 @@ else
                --ignore-sigpipe
                --ignore-write-errors
                --disable-write-exception
+               --reload-on-rss 500
 fi


### PR DESCRIPTION
uWSGI worker processes seem to grow until they hit allocation limits. It is not known why this happens, but restarting the worker when they hit 500MB RSS removes some memory pressure on servers.