### PR TITLE
Fix ValueError in MobilitySerializer

### DIFF
--- a/services/api.py
+++ b/services/api.py
@@ -360,7 +360,11 @@ class MobilitySerializer(ServiceNodeSerializer):
             ret["parent"] = obj.parent_id
         ret["root"] = self.root_service_nodes(obj)
         ret["related_services"] = (
-            [int(service) for service in obj.service_reference.split(",")]
+            [
+                int(service)
+                for service in obj.service_reference.split(",")
+                if service.isdigit()
+            ]
             if obj.service_reference
             else []
         )

--- a/services/tests/test_mobility_api.py
+++ b/services/tests/test_mobility_api.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+
+import pytest
+import pytz
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from services.models import MobilityServiceNode
+from services.tests.utils import get
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.mark.django_db
+def test_get_mobility_list(api_client):
+    MobilityServiceNode.objects.create(
+        id=1, name="Urheilukeskus", last_modified_time=datetime.now(pytz.utc)
+    )
+    MobilityServiceNode.objects.create(
+        id=2,
+        name="Kenttä",
+        last_modified_time=datetime.now(pytz.utc),
+        service_reference="1+2",
+    )  # Test that non-integer values in `service_reference` don't break the endpoint
+
+    response = get(api_client, reverse("mobilityservicenode-list"))
+
+    assert response.status_code == 200
+    assert response.data["count"] == 2


### PR DESCRIPTION
Handle cases where MobilityServiceNode's `service_reference` contains non-integer values. In such cases we otherwise get `ValueError: invalid literal for int() with base 10` and the endpoint breaks.