### PR TITLE
Use only departments with unit view organization-filter

### DIFF
--- a/services/api.py
+++ b/services/api.py
@@ -1003,13 +1003,9 @@ class UnitViewSet(
                             "'organization' value must be a valid UUID"
                         )
 
-                deps = Department.objects.filter(uuid__in=deps_uuids).select_related(
-                    "municipality"
-                )
-                munis = [d.municipality for d in deps]
-
-                queryset = queryset.filter(root_department__in=deps) | queryset.filter(
-                    municipality__in=munis
+                deps = Department.objects.filter(uuid__in=deps_uuids)
+                queryset = queryset.filter(department__in=deps) | queryset.filter(
+                    root_department__in=deps
                 )
 
         if "provider_type" in filters:

--- a/services/tests/test_unit_view_set_api.py
+++ b/services/tests/test_unit_view_set_api.py
@@ -3,33 +3,68 @@ from datetime import datetime
 import pytest
 import pytz
 from django.urls import reverse
+from munigeo.models import (
+    AdministrativeDivision,
+    AdministrativeDivisionType,
+    Municipality,
+)
 from rest_framework.test import APIClient
 
-from services.models import Unit
+from services.api import make_muni_ocd_id
+from services.models import Department, Unit
 from services.tests.utils import get
 
 
 def create_units():
     utc_timezone = pytz.timezone("UTC")
+    municipality_id = "helsinki"
+    division_type = AdministrativeDivisionType.objects.create(type="muni")
+    division = AdministrativeDivision.objects.create(
+        type=division_type,
+        name=municipality_id,
+        ocd_id=make_muni_ocd_id(municipality_id),
+    )
+    municipality = Municipality.objects.create(
+        id=municipality_id, name=municipality_id, division=division
+    )
+    organization = Department.objects.create(
+        name_fi="Helsingin kaupunki",
+        municipality=municipality,
+        uuid="83e74666-0836-4c1d-948a-4b34a8b90301",
+    )
+    department = Department.objects.create(
+        name_fi="Stara",
+        uuid="a10eb4e7-c7e3-49ec-b6cd-54a1cb74adf8",
+    )
     # Unit with public service
     Unit.objects.create(
         id=1,
         last_modified_time=datetime.now(utc_timezone),
         displayed_service_owner_type="MUNICIPAL_SERVICE",
+        root_department=organization,
+        municipality=municipality,
     )
     # Unit with private service
     Unit.objects.create(
         id=2,
         last_modified_time=datetime.now(utc_timezone),
         displayed_service_owner_type="PRIVATE_SERVICE",
+        root_department=organization,
+        department=department,
     )
     # Unit with public enterprise
     Unit.objects.create(
-        id=3, last_modified_time=datetime.now(utc_timezone), organizer_type=6
+        id=3,
+        last_modified_time=datetime.now(utc_timezone),
+        organizer_type=6,
+        municipality=municipality,
     )
     # Unit with private enterprise
     Unit.objects.create(
-        id=4, last_modified_time=datetime.now(utc_timezone), organizer_type=10
+        id=4,
+        last_modified_time=datetime.now(utc_timezone),
+        organizer_type=10,
+        department=department,
     )
     # Non-public unit
     Unit.objects.create(
@@ -73,6 +108,89 @@ def test_no_private_services_filter(api_client):
     create_units()
 
     response = get(api_client, reverse("unit-list"), data={"no_private_services": True})
+    results = response.data["results"]
+
+    assert response.status_code == 200
+    assert response.data["count"] == 2
+    assert results[0]["id"] == 3
+    assert results[1]["id"] == 1
+
+
+@pytest.mark.django_db
+def test_organizations_filter(api_client):
+    """
+    Test that organization's units are visible in unit view when "organization" parameter is given.
+    """
+    create_units()
+
+    response = get(
+        api_client,
+        reverse("unit-list"),
+        data={"organization": "83e74666-0836-4c1d-948a-4b34a8b90301"},
+    )
+    results = response.data["results"]
+
+    assert response.status_code == 200
+    assert response.data["count"] == 2
+    assert results[0]["id"] == 2
+    assert results[1]["id"] == 1
+
+
+@pytest.mark.django_db
+def test_organizations_filter_with_department(api_client):
+    """
+    Test that department's units are visible in unit view when "organization" parameter is given.
+    """
+    create_units()
+
+    response = get(
+        api_client,
+        reverse("unit-list"),
+        data={"organization": "a10eb4e7-c7e3-49ec-b6cd-54a1cb74adf8"},
+    )
+    results = response.data["results"]
+
+    assert response.status_code == 200
+    assert response.data["count"] == 2
+    assert results[0]["id"] == 4
+    assert results[1]["id"] == 2
+
+
+@pytest.mark.django_db
+def test_organizations_filter_with_multiple_departments(api_client):
+    """
+    Test that department's units are visible in unit view when multiple "organization" parameters are given.
+    """
+    create_units()
+
+    response = get(
+        api_client,
+        reverse("unit-list"),
+        data={
+            "organization": "83e74666-0836-4c1d-948a-4b34a8b90301,a10eb4e7-c7e3-49ec-b6cd-54a1cb74adf8"
+        },
+    )
+    results = response.data["results"]
+
+    assert response.status_code == 200
+    assert response.data["count"] == 3
+    assert results[0]["id"] == 4
+    assert results[1]["id"] == 2
+    assert results[2]["id"] == 1
+
+
+@pytest.mark.django_db
+def test_municipality_filter(api_client):
+    """
+    Test that municipality's units are visible in unit view when "municipality" parameter is given.
+    """
+    create_units()
+
+    response = get(
+        api_client,
+        reverse("unit-list"),
+        data={"municipality": "helsinki"},
+    )
     results = response.data["results"]
 
     assert response.status_code == 200


### PR DESCRIPTION
## Description

Updates for unit view:
- Filter with unit root_departments and departments with organization-filter
- Do not auto-include department's municipalities
- Add tests

## Context

[Refs](https://trello.com/c/7MBPQSbo/1448-unit-n%C3%A4kym%C3%A4n-organization-filter-ottaa-automaattisesti-mukaan-my%C3%B6s-departmenttien-kunnat-vaikka-ei-pit%C3%A4isi)

## How Has This Been Tested?

Manually and through added unit tests.

## Manual Testing Instructions for Reviewers

Test with different organization-parameters and observe results.
