### PR TITLE
Fix typo in CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [ develop, master ]
   pull_request:
-    branches: [ develop. master ]
+    branches: [ develop, master ]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,11 @@ jobs:
 
       # Without this workaround Sonar reports a warning about an incorrect source path
       - name: Override coverage report source path for Sonar
+        if: github.event_name == 'push'
         run: sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' coverage.xml
 
       - name: SonarCloud Scan
+        if: github.event_name == 'push'
         uses: SonarSource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
To ensure that the tests run when opening a new PR, fix a small typo in the CI configuration.

Also, as agreed within the project, skip SonarCloud scan in PRs.
