### PR TITLE
Expand no_private_services filter to exclude "not displayed" services

### DIFF
--- a/services/api.py
+++ b/services/api.py
@@ -1161,6 +1161,7 @@ class UnitViewSet(
             )
             queryset = queryset.exclude(
                 Q(displayed_service_owner_type__iexact="PRIVATE_SERVICE")
+                | Q(displayed_service_owner_type__iexact="NOT_DISPLAYED")
                 | Q(organizer_type=private_enterprise_value)
             )
 

--- a/services/tests/test_unit_view_set_api.py
+++ b/services/tests/test_unit_view_set_api.py
@@ -78,6 +78,13 @@ def create_units():
         id=6, last_modified_time=datetime.now(UTC_TIMEZONE), is_active=False
     )
 
+    # Unit with "not displayed" service
+    Unit.objects.create(
+        id=7,
+        last_modified_time=datetime.now(UTC_TIMEZONE),
+        displayed_service_owner_type="NOT_DISPLAYED",
+    )
+
 
 def create_service_nodes():
     service_node_1 = ServiceNode.objects.create(
@@ -139,11 +146,12 @@ def test_get_unit_list(api_client):
     results = response.data["results"]
 
     assert response.status_code == 200
-    assert response.data["count"] == 4
-    assert results[0]["id"] == 4
-    assert results[1]["id"] == 3
-    assert results[2]["id"] == 2
-    assert results[3]["id"] == 1
+    assert response.data["count"] == 5
+    assert results[0]["id"] == 7
+    assert results[1]["id"] == 4
+    assert results[2]["id"] == 3
+    assert results[3]["id"] == 2
+    assert results[4]["id"] == 1
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Description

Add `NOT_DISPLAYED` services to the `no_private_services` unit filter.

## Context

[Refs](https://trello.com/c/pxqvASbv/1426-liikkumisn%C3%A4kym%C3%A4n-ylimm%C3%A4t-solmut-eiv%C3%A4t-palauta-mit%C3%A4%C3%A4n)

## How Has This Been Tested?

Unit test and locally testing the enpoint.
