### PR TITLE
Filter Administrative Divisions by address

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -30,3 +30,4 @@ parso
 whitenoise
 libvoikko
 bmi-arcgis-restapi
+geopy

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,6 +79,10 @@ flake8==6.1.0
     # via
     #   -r requirements.in
     #   pep8-naming
+geographiclib==2.0
+    # via geopy
+geopy==2.4.0
+    # via -r requirements.in
 idna==3.4
     # via requests
 importlib-metadata==6.8.0

--- a/services/api.py
+++ b/services/api.py
@@ -43,6 +43,7 @@ from services.models import (
 )
 from services.models.unit import ORGANIZER_TYPES, PROVIDER_TYPES
 from services.utils import check_valid_concrete_field, strtobool
+from services.utils.geocode_address import geocode_address
 
 if settings.REST_FRAMEWORK and settings.REST_FRAMEWORK["DEFAULT_RENDERER_CLASSES"]:
     DEFAULT_RENDERERS = [
@@ -1347,6 +1348,24 @@ class AdministrativeDivisionSerializer(munigeo_api.AdministrativeDivisionSeriali
 
 class AdministrativeDivisionViewSet(munigeo_api.AdministrativeDivisionViewSet):
     serializer_class = AdministrativeDivisionSerializer
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        filters = self.request.query_params
+
+        if "address" in filters and "municipality" in filters:
+            street_address = filters["address"]
+            municipality = filters["municipality"]
+            country = settings.DEFAULT_COUNTRY
+            address = f"{street_address}, {municipality}, {country}"
+            location_coordinates = geocode_address(address)
+            if location_coordinates:
+                point = Point(
+                    location_coordinates[1], location_coordinates[0], srid=4326
+                )
+                queryset = queryset.filter(geometry__boundary__contains=point)
+
+        return queryset
 
 
 register_view(AdministrativeDivisionViewSet, "administrative_division")

--- a/services/tests/test_administrative_division_view_set_api.py
+++ b/services/tests/test_administrative_division_view_set_api.py
@@ -1,0 +1,27 @@
+import pytest
+from django.urls import reverse
+from munigeo.models import AdministrativeDivision, AdministrativeDivisionType
+from rest_framework.test import APIClient
+
+from services.api import make_muni_ocd_id
+from services.tests.utils import get
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.mark.django_db
+def test_get_administrative_division_list(api_client):
+    municipality_id = "helsinki"
+    division_type = AdministrativeDivisionType.objects.create(type="muni")
+    AdministrativeDivision.objects.create(
+        type=division_type,
+        name=municipality_id,
+        ocd_id=make_muni_ocd_id(municipality_id),
+    )
+
+    response = get(api_client, reverse("administrativedivision-list"))
+    assert response.status_code == 200
+    assert response.data["count"] == 1

--- a/services/tests/test_administrative_division_view_set_api.py
+++ b/services/tests/test_administrative_division_view_set_api.py
@@ -1,10 +1,29 @@
 import pytest
 from django.urls import reverse
-from munigeo.models import AdministrativeDivision, AdministrativeDivisionType
+from munigeo.models import (
+    AdministrativeDivision,
+    AdministrativeDivisionType,
+    Municipality,
+)
 from rest_framework.test import APIClient
 
 from services.api import make_muni_ocd_id
 from services.tests.utils import get
+
+
+def create_administrative_divisions():
+    municipality_ids = ["helsinki", "espoo", "vantaa"]
+    division_type = AdministrativeDivisionType.objects.create(type="muni")
+    for municipality_id in municipality_ids:
+        municipality = Municipality.objects.create(
+            id=municipality_id, name=municipality_id
+        )
+        AdministrativeDivision.objects.create(
+            type=division_type,
+            name=municipality_id,
+            ocd_id=make_muni_ocd_id(municipality_id),
+            municipality=municipality,
+        )
 
 
 @pytest.fixture
@@ -14,14 +33,20 @@ def api_client():
 
 @pytest.mark.django_db
 def test_get_administrative_division_list(api_client):
-    municipality_id = "helsinki"
-    division_type = AdministrativeDivisionType.objects.create(type="muni")
-    AdministrativeDivision.objects.create(
-        type=division_type,
-        name=municipality_id,
-        ocd_id=make_muni_ocd_id(municipality_id),
-    )
-
+    create_administrative_divisions()
     response = get(api_client, reverse("administrativedivision-list"))
     assert response.status_code == 200
+    assert response.data["count"] == 3
+
+
+@pytest.mark.django_db
+def test_municipality_filter(api_client):
+    create_administrative_divisions()
+    response = get(
+        api_client,
+        reverse("administrativedivision-list"),
+        data={"municipality": "helsinki"},
+    )
+    assert response.status_code == 200
     assert response.data["count"] == 1
+    assert response.data["results"][0]["municipality"] == "helsinki"

--- a/services/utils/geocode_address.py
+++ b/services/utils/geocode_address.py
@@ -1,0 +1,12 @@
+from geopy.geocoders import Nominatim
+
+
+def geocode_address(address):
+    """
+    Geocodes address and returns location coordinates.
+    """
+    geolocator = Nominatim(user_agent="smbackend")
+    location = geolocator.geocode(address)
+    if location:
+        return location.latitude, location.longitude
+    return None


### PR DESCRIPTION
## Description

Add an option to filter Administrative Divisions by address. The given address is geocoded to a point and used to filter the results by the divisions that contain the point.

## Context
[Refs](https://trello.com/c/9VYVHYXL/1094-1-alueen-haku-osoitteen-perusteella)

## How Has This Been Tested?

Added unit tests for Administrative Division list endpoint and municipality filter before the new changes to make sure the changes don't break the existing functionality. Added a new test for the address filter. Also some local manual testing for the endpoint.
