### PR TITLE
Fix broken geo_import due to urllib3 version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -31,3 +31,4 @@ whitenoise
 libvoikko
 bmi-arcgis-restapi
 geopy
+urllib3<2

--- a/requirements.txt
+++ b/requirements.txt
@@ -187,8 +187,9 @@ typing-extensions==4.8.0
     #   django-modeltranslation
 url-normalize==1.4.3
     # via requests-cache
-urllib3==2.0.7
+urllib3==1.26.18
     # via
+    #   -r requirements.in
     #   bmi-arcgis-restapi
     #   requests
     #   requests-cache


### PR DESCRIPTION
## Description
Pinned urllib3 to version <2 to resolve `TypeError` caused by deprecated `method_whitelist` in urllib3 2.0.0.

## Context

[Refs](https://trello.com/c/sEF172jr/1468-kultakruununkaari-2-paikkatietohakuun)