### PR TITLE
Fix translated fields in OpenAPI docs

### DIFF
--- a/services/tests/test_administrative_division_view_set_api.py
+++ b/services/tests/test_administrative_division_view_set_api.py
@@ -104,3 +104,24 @@ def test_address_filter(api_client):
 
     assert response.status_code == 200
     assert response.data["count"] == 0
+
+
+@pytest.mark.django_db
+def test_translations(api_client):
+    """
+    Test that the translations are returned correctly.
+    """
+    create_administrative_divisions()
+    division = AdministrativeDivision.objects.get(name="helsinki")
+    division.name_fi = "Eteläinen"
+    division.name_sv = "Södra"
+    division.save()
+
+    response = get(
+        api_client,
+        reverse("administrativedivision-list"),
+        data={"municipality": "helsinki"},
+    )
+
+    assert response.data["results"][0]["name"]["fi"] == "Eteläinen"
+    assert response.data["results"][0]["name"]["sv"] == "Södra"

--- a/services/tests/test_mobility_api.py
+++ b/services/tests/test_mobility_api.py
@@ -30,3 +30,19 @@ def test_get_mobility_list(api_client):
 
     assert response.status_code == 200
     assert response.data["count"] == 2
+
+
+@pytest.mark.django_db
+def test_translations(api_client):
+    """
+    Test that translations are returned correctly.
+    """
+    MobilityServiceNode.objects.create(
+        id=1,
+        name="Frisbeegolf-rata",
+        name_sv="Frisbeegolfbana",
+        last_modified_time=datetime.now(pytz.utc),
+    )
+    response = get(api_client, reverse("mobilityservicenode-list"))
+    assert response.data["results"][0]["name"]["fi"] == "Frisbeegolf-rata"
+    assert response.data["results"][0]["name"]["sv"] == "Frisbeegolfbana"

--- a/services/tests/test_unit_view_set_api.py
+++ b/services/tests/test_unit_view_set_api.py
@@ -48,6 +48,9 @@ def create_units():
         displayed_service_owner_type="MUNICIPAL_SERVICE",
         root_department=organization,
         municipality=municipality,
+        description_fi="Kuvaus suomeksi",
+        description_sv="Beskrivning på svenska",
+        description_en="Description in English",
     )
     # Unit with private service
     Unit.objects.create(
@@ -377,3 +380,18 @@ def test_geometry_3d_parameter(api_client):
         results[4]["geometry_3d"]["coordinates"]
         == munigeo_api.geom_to_json(geometry_3d, DEFAULT_SRS)["coordinates"]
     )
+
+
+@pytest.mark.django_db
+def test_translations(api_client):
+    """
+    Test that translations are returned correctly.
+    """
+    create_units()
+    response = get(api_client, reverse("unit-list"))
+    results = response.data["results"]
+    unit_with_translations = results[4]
+    assert unit_with_translations["id"] == 1
+    assert unit_with_translations["description"]["fi"] == "Kuvaus suomeksi"
+    assert unit_with_translations["description"]["sv"] == "Beskrivning på svenska"
+    assert unit_with_translations["description"]["en"] == "Description in English"


### PR DESCRIPTION
## Description

The translated fields did not display correctly by default. Add custom `TranslationsField` to fix this.

## Context

Related to #206 

## How Has This Been Tested?

Added some unit tests for translated fields before the change to make sure the API is still working as expected.


## Screenshots

Example before changes: 
<img width="261" alt="before" src="https://github.com/City-of-Helsinki/smbackend/assets/10584178/01686d22-a3d2-47f9-aaae-e02bf8ad46bd">

After fix: 
<img width="283" alt="after" src="https://github.com/City-of-Helsinki/smbackend/assets/10584178/010dd1e9-f9fb-4efc-bb80-82d655d154a1">

