### PR TITLE
Add apt-get update to CI package installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install required Ubuntu packages
         run: |
-          sudo apt-get install gdal-bin voikko-fi libvoikko-dev
+          sudo apt-get update && sudo apt-get install gdal-bin voikko-fi libvoikko-dev
 
       - name: Create needed postgis extensions
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     branches: [ develop, master ]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python: [ "3.10" , "3.11" ]


### PR DESCRIPTION
Fix failing CI build by adding `apt-get update` to the package installation.
