### PR TITLE
Set GDAL_HTTP_UNSAFESSL=YES in weekly hsy import

### DIFF
--- a/scripts/run_imports.sh
+++ b/scripts/run_imports.sh
@@ -16,7 +16,7 @@ function stage_1 {
     # Helsinki, Espoo and HSY Administrative divisions and Addresses
     #./manage.py geo_import helsinki --divisions
     #./manage.py geo_import espoo --divisions
-    ./manage.py geo_import hsy --divisions
+    GDAL_HTTP_UNSAFESSL=YES ./manage.py geo_import hsy --divisions
     ./manage.py geo_import helsinki --addresses
     ./manage.py geo_import uusimaa --addresses
     ./manage.py index_search_columns


### PR DESCRIPTION
## Description

During the weekly import the `./manage.py geo_import hsy --divisions` command was failing with the following error: _ERROR: GDAL_ERROR 1: b'SSL certificate problem: unable to get local issuer certificate'_

Set GDAL_HTTP_UNSAFESSL to "YES" get around the issue for now.

## Context

[Refs](https://trello.com/c/jMvyGdPC/1479-viikottaisen-importin-ongelmien-korjaus)

