### PR TITLE
Remove service_point_id from AdministrativeDivision

### DIFF
--- a/services/api.py
+++ b/services/api.py
@@ -1370,20 +1370,6 @@ class AdministrativeDivisionSerializer(munigeo_api.AdministrativeDivisionSeriali
 
         query_params = self.context["request"].query_params
         unit_include = query_params.get("unit_include", None)
-        service_point_id = ret["service_point_id"]
-        if service_point_id and unit_include:
-            try:
-                unit = Unit.objects.get(id=service_point_id)
-            except Unit.DoesNotExist:
-                try:
-                    unit_alias = UnitAlias.objects.get(second=service_point_id)
-                    unit = unit_alias.first
-                except UnitAlias.DoesNotExist:
-                    unit = None
-            if unit:
-                ser = UnitSerializer(unit, context={"only": unit_include.split(",")})
-                ret["unit"] = ser.data
-
         unit_ids = ret["units"]
         if unit_ids and unit_include:
             units = Unit.objects.filter(id__in=unit_ids)

--- a/services/management/commands/verify_school_districts.py
+++ b/services/management/commands/verify_school_districts.py
@@ -24,13 +24,13 @@ def get_division_units():
         for division in adm_type.administrativedivision_set.filter(
             end__gt=datetime.date(year=2017, month=3, day=16)
         ):
-            service_point_id = division.service_point_id
-            if service_point_id:
+            unit_ids = division.units
+            for unit_id in unit_ids:
                 try:
-                    unit = Unit.objects.get(id=int(service_point_id))
+                    unit = Unit.objects.get(id=int(unit_id))
                 except Unit.DoesNotExist:
                     try:
-                        unit_alias = UnitAlias.objects.get(second=service_point_id)
+                        unit_alias = UnitAlias.objects.get(second=unit_id)
                         unit = unit_alias.first
                     except UnitAlias.DoesNotExist:
                         unit = None
@@ -38,7 +38,7 @@ def get_division_units():
                     {
                         "unit": unit,
                         "division": division,
-                        "origin_service_point_id": service_point_id,
+                        "origin_unit_id": unit_id,
                         "time": (division.start, division.end),
                         "type": adm_type,
                     }


### PR DESCRIPTION
NB! Django-munigeo [PR 58](https://github.com/City-of-Helsinki/django-munigeo/pull/58) needs to merged and published and upgraded to smbackend before merging this PR.

## Description

As `service_point_id` has been fully replaced by `units` field in django-munigeo `AdministrativeDivision` model, it can be removed from smbackend as well.

## Context

[Refs](https://trello.com/c/euA1Ebrp/1078-2-alue-importit-p%C3%A4ivitet%C3%A4%C3%A4n-kaikki-toimipisteid-l%C3%A4hteet-k%C3%A4ytt%C3%A4m%C3%A4%C3%A4n-unitsia)

## How Has This Been Tested?

The Helsinki imports have been run locally with the new changes.
