### PR TITLE
Add update_vantaa_parking_areas to weekly import

### DIFF
--- a/scripts/run_imports.sh
+++ b/scripts/run_imports.sh
@@ -19,6 +19,7 @@ function stage_1 {
     GDAL_HTTP_UNSAFESSL=YES ./manage.py geo_import hsy --divisions
     ./manage.py geo_import helsinki --addresses
     ./manage.py geo_import uusimaa --addresses
+    ./manage.py update_vantaa_parking_areas
     ./manage.py index_search_columns
 }
 


### PR DESCRIPTION
## Description

Update Vantaa parking areas automatically weekly.

## Context

[Refs](https://trello.com/c/azf1kGsm/1496-vantaan-pys%C3%A4k%C3%B6intialueet-eiv%C3%A4t-p%C3%A4ivity-palvelukarttaan)
