### PR TITLE
Docker setup: define a volume to enable local development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
         env_file:
             - .env
         volumes:
+            - .:/smbackend
             - django-media:/var/media/
         ports:
             - "8000:8000"


### PR DESCRIPTION
Define a volume to enable local development with Docker without having to start the container after every change.
