### PR TITLE
Update statistical districts years

### DIFF
--- a/services/management/commands/statistical_queries/espoo_population_by_age.json
+++ b/services/management/commands/statistical_queries/espoo_population_by_age.json
@@ -139,7 +139,7 @@
       "selection": {
         "filter": "item",
         "values": [
-          "2021"
+          "2022"
         ]
       }
     }

--- a/services/management/commands/statistical_queries/espoo_population_forecast.json
+++ b/services/management/commands/statistical_queries/espoo_population_forecast.json
@@ -139,7 +139,7 @@
       "selection": {
         "filter": "item",
         "values": [
-          "2027"
+          "2029"
         ]
       }
     }

--- a/services/management/commands/statistical_queries/espoo_population_forecast.json
+++ b/services/management/commands/statistical_queries/espoo_population_forecast.json
@@ -130,7 +130,7 @@
       "selection": {
         "filter": "item",
         "values": [
-          "PER21"
+          "2022"
         ]
       }
     },

--- a/services/management/commands/statistical_queries/helsinki_population_by_age.json
+++ b/services/management/commands/statistical_queries/helsinki_population_by_age.json
@@ -199,7 +199,7 @@
       "selection": {
         "filter": "item",
         "values": [
-          "2021"
+          "2022"
         ]
       }
     }

--- a/services/management/commands/statistical_queries/helsinki_population_forecast.json
+++ b/services/management/commands/statistical_queries/helsinki_population_forecast.json
@@ -199,7 +199,7 @@
       "selection": {
         "filter": "item",
         "values": [
-          "2027"
+          "2029"
         ]
       }
     }

--- a/services/management/commands/statistical_queries/vantaa_population_by_age.json
+++ b/services/management/commands/statistical_queries/vantaa_population_by_age.json
@@ -108,7 +108,7 @@
       "selection": {
         "filter": "item",
         "values": [
-          "2021"
+          "2022"
         ]
       }
     }

--- a/services/management/commands/statistical_queries/vantaa_population_forecast.json
+++ b/services/management/commands/statistical_queries/vantaa_population_forecast.json
@@ -100,7 +100,7 @@
       "selection": {
         "filter": "item",
         "values": [
-          "PER21"
+          "7"
         ]
       }
     },

--- a/services/management/commands/statistical_queries/vantaa_population_forecast.json
+++ b/services/management/commands/statistical_queries/vantaa_population_forecast.json
@@ -109,7 +109,7 @@
       "selection": {
         "filter": "item",
         "values": [
-          "2027"
+          "2029"
         ]
       }
     }


### PR DESCRIPTION
## Description

Update the year of statistical districts population by age to the newest available year 2022. Update the population forecast to the year 2029, forecasting five years ahead.

## Context

[Refs](https://trello.com/c/mDGCGVEI/1372-v%C3%A4est%C3%B6tiedot-ja-ennuste)
