### PR TITLE
Fix pytest warning

### DIFF
--- a/observations/tests/fixtures.py
+++ b/observations/tests/fixtures.py
@@ -22,7 +22,6 @@ def api_client():
     return APIClient()
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def user():
     username = "test_user"
@@ -41,7 +40,6 @@ def user():
     return {"username": username, "password": password}
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def organization():
     return Department.objects.create(
@@ -49,7 +47,6 @@ def organization():
     )
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def service():
     return Service.objects.create(
@@ -57,7 +54,6 @@ def service():
     )
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def unit(service, organization):
     unit = Unit.objects.create(
@@ -71,7 +67,6 @@ def unit(service, organization):
     return unit
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def categorical_observations(unit, observable_property):
     return [
@@ -102,7 +97,6 @@ def categorical_observations(unit, observable_property):
     ]
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def descriptive_observations(unit, descriptive_property):
     value = AllowedValue.objects.create(
@@ -121,7 +115,6 @@ def descriptive_observations(unit, descriptive_property):
     ]
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def observable_property(service, unit):
     p = ObservableProperty.objects.create(
@@ -155,7 +148,6 @@ def observable_property(service, unit):
     return p
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def unit_latest_observation(observable_property, unit, categorical_observations):
     return UnitLatestObservation.objects.create(
@@ -163,7 +155,6 @@ def unit_latest_observation(observable_property, unit, categorical_observations)
     )
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def unit_latest_observation_expired(
     observable_property, unit, categorical_observations
@@ -173,7 +164,6 @@ def unit_latest_observation_expired(
     )
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def unit_latest_observation_both_expired_and_not_expirable(
     descriptive_property,
@@ -192,7 +182,6 @@ def unit_latest_observation_both_expired_and_not_expirable(
     }
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def descriptive_property(service, unit):
     p = ObservableProperty.objects.create(

--- a/services/search/tests/conftest.py
+++ b/services/search/tests/conftest.py
@@ -32,7 +32,6 @@ def api_client():
     return APIClient()
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def units(
     services,
@@ -115,7 +114,6 @@ def units(
     return Unit.objects.all().order_by("id")
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def department(municipality):
     return Department.objects.create(
@@ -126,7 +124,6 @@ def department(municipality):
     )
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def accessibility_shortcoming(units):
     return UnitAccessibilityShortcomings.objects.create(
@@ -134,7 +131,6 @@ def accessibility_shortcoming(units):
     )
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def services():
     Service.objects.create(
@@ -169,7 +165,6 @@ def services():
     return Service.objects.all()
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def service_nodes(services):
     leisure = ServiceNode.objects.create(
@@ -193,7 +188,6 @@ def service_nodes(services):
     return ServiceNode.objects.all()
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def addresses(streets, municipality):
     Address.objects.create(
@@ -245,7 +239,6 @@ def addresses(streets, municipality):
     return Address.objects.all()
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def municipality():
     return Municipality.objects.create(
@@ -253,7 +246,6 @@ def municipality():
     )
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def administrative_division_type():
     return AdministrativeDivisionType.objects.get_or_create(
@@ -261,7 +253,6 @@ def administrative_division_type():
     )
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def administrative_division(administrative_division_type):
     adm_div = AdministrativeDivision.objects.get_or_create(
@@ -273,7 +264,6 @@ def administrative_division(administrative_division_type):
     return adm_div
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def streets():
     Street.objects.create(


### PR DESCRIPTION
Fix PytestRemovedIn9Warning: Marks applied to fixtures have no effect.