### PR TITLE
Add new data sources to Vantaa parking data import

### DIFF
--- a/services/management/commands/update_vantaa_parking_areas.py
+++ b/services/management/commands/update_vantaa_parking_areas.py
@@ -164,18 +164,22 @@ class Command(BaseCommand):
 
             updated_parking_areas = []
             for feature in features:
-                geom = self.get_multi_geom(
-                    GEOSGeometry(str(feature.get("geometry")), srid=SRC_SRID)
-                )
-                geom.transform(src_to_dest)
+                geometry = feature.get("geometry")
                 props = feature.get("properties")
+                name_fi = props.get("tyyppi")
+
+                if not geometry:
+                    logger.warning(f"Parking area {name_fi} has no geometry, skipping")
+                    continue
+                geom = self.get_multi_geom(GEOSGeometry(str(geometry), srid=SRC_SRID))
+                geom.transform(src_to_dest)
+
                 origin_id = (
                     str(props.get("objectid")) if props.get("objectid") else None
                 )
                 if not origin_id:
                     logger.warning("Parking area has no origin ID, skipping")
                     continue
-                name_fi = props.get("tyyppi")
                 defaults = {
                     "name_fi": name_fi,
                     "municipality": municipality,

--- a/services/management/commands/update_vantaa_parking_areas.py
+++ b/services/management/commands/update_vantaa_parking_areas.py
@@ -58,6 +58,13 @@ DATA_SOURCES = [
         "layer_name": "Raskaan liikenteen sallitut kadunvarret MUOKATTAVA",
         "ocd_id_base": "ocd-division/country:fi/kunta:vantaa/raskaanliikenteen-sallittu-kadunvarsi-alue:",
     },
+    {
+        "type": "hgv_no_parking_area",
+        "service_url": "https://matti.vantaa.fi/server2/rest/services/Hosted/Raskaan_liikenteen_kielletyt_kadunvarret/"
+        "FeatureServer",
+        "layer_name": "Raskaan liikenteen kielletyt kadunvarret MUOKATTAVA",
+        "ocd_id_base": "ocd-division/country:fi/kunta:vantaa/raskaanliikenteen-kielletty-kadunvarsi-alue:",
+    },
 ]
 
 SRC_SRID = 4326

--- a/services/management/commands/update_vantaa_parking_areas.py
+++ b/services/management/commands/update_vantaa_parking_areas.py
@@ -23,45 +23,26 @@ import restapi  # noqa: E402
 
 logger = logging.getLogger("services.management")
 
-OCD_ID_VANTAA_PARKING_BASE = (
-    "ocd-division/country:fi/kunta:vantaa/pysakointipaikka-alue:"
-)
-AREA_SERVICE_URL = "https://matti.vantaa.fi/server2/rest/services/Hosted/Pys%C3%A4k%C3%B6intialueet/FeatureServer"
-AREA_LAYER_NAME = "Pyskintialueet MUOKATTAVA"
-AREA_TYPE = "parking_area"
-
-OCD_ID_VANTAA_STREET_PARKING_BASE = (
-    "ocd-division/country:fi/kunta:vantaa/kadunvarsipysakointi-alue:"
-)
-STREET_SERVICE_URL = "https://matti.vantaa.fi/server2/rest/services/Hosted/Kadunvarsipys%C3%A4k%C3%B6inti/FeatureServer"
-STREET_LAYER_NAME = "Kadunvarsipysäköinti MUOKATTAVA"
-STREET_TYPE = "street_parking_area"
-
-OCD_ID_VANTAA_PARK_AND_RIDE_PARKING_BASE = (
-    "ocd-division/country:fi/kunta:vantaa/liityntapysakointi-alue:"
-)
-PARK_AND_RIDE_SERVICE_URL = "https://matti.vantaa.fi/server2/rest/services/Hosted/Liitynt%C3%A4pys%C3%A4k%C3%B6intialueet/FeatureServer"
-PARK_AND_RIDE_LAYER_NAME = "Liityntäpysäköintialueet MUOKATTAVA"
-PARK_AND_RIDE_TYPE = "park_and_ride_area"
-
 DATA_SOURCES = [
     {
-        "service_url": AREA_SERVICE_URL,
-        "layer_name": AREA_LAYER_NAME,
-        "type": AREA_TYPE,
-        "ocd_id_base": OCD_ID_VANTAA_PARKING_BASE,
+        "type": "parking_area",
+        "service_url": "https://matti.vantaa.fi/server2/rest/services/Hosted/Pys%C3%A4k%C3%B6intialueet/FeatureServer",
+        "layer_name": "Pysäköintialueet MUOKATTAVA",
+        "ocd_id_base": "ocd-division/country:fi/kunta:vantaa/pysakointipaikka-alue:",
     },
     {
-        "service_url": STREET_SERVICE_URL,
-        "layer_name": STREET_LAYER_NAME,
-        "type": STREET_TYPE,
-        "ocd_id_base": OCD_ID_VANTAA_STREET_PARKING_BASE,
+        "type": "street_parking_area",
+        "service_url": "https://matti.vantaa.fi/server2/rest/services/Hosted/Kadunvarsipys%C3%A4k%C3%B6inti/"
+        "FeatureServer",
+        "layer_name": "Kadunvarsipysäköinti MUOKATTAVA",
+        "ocd_id_base": "ocd-division/country:fi/kunta:vantaa/kadunvarsipysakointi-alue:",
     },
     {
-        "service_url": PARK_AND_RIDE_SERVICE_URL,
-        "layer_name": PARK_AND_RIDE_LAYER_NAME,
-        "type": PARK_AND_RIDE_TYPE,
-        "ocd_id_base": OCD_ID_VANTAA_PARK_AND_RIDE_PARKING_BASE,
+        "type": "park_and_ride_area",
+        "service_url": "https://matti.vantaa.fi/server2/rest/services/Hosted/Liitynt%C3%A4pys%C3%A4k%C3%B6intialueet/"
+        "FeatureServer",
+        "layer_name": "Liityntäpysäköintialueet MUOKATTAVA",
+        "ocd_id_base": "ocd-division/country:fi/kunta:vantaa/liityntapysakointi-alue:",
     },
 ]
 

--- a/services/management/commands/update_vantaa_parking_areas.py
+++ b/services/management/commands/update_vantaa_parking_areas.py
@@ -45,6 +45,13 @@ DATA_SOURCES = [
         "ocd_id_base": "ocd-division/country:fi/kunta:vantaa/liityntapysakointi-alue:",
     },
     {
+        "type": "hgv_parking_area",
+        "service_url": "https://matti.vantaa.fi/server2/rest/services/Hosted/Raskaan_liikenteen_"
+        "pys%C3%A4k%C3%B6intialueet/FeatureServer",
+        "layer_name": "Raskaan liikenteen pysäköintialueet MUOKATTAVA",
+        "ocd_id_base": "ocd-division/country:fi/kunta:vantaa/raskaanliikenteen-pysakointipaikka-alue:",
+    },
+    {
         "type": "hgv_street_parking_area",
         "service_url": "https://matti.vantaa.fi/server2/rest/services/Hosted/Raskaan_liikenteen_sallitut_kadunvarret/"
         "FeatureServer",

--- a/services/management/commands/update_vantaa_parking_areas.py
+++ b/services/management/commands/update_vantaa_parking_areas.py
@@ -44,6 +44,13 @@ DATA_SOURCES = [
         "layer_name": "Liityntäpysäköintialueet MUOKATTAVA",
         "ocd_id_base": "ocd-division/country:fi/kunta:vantaa/liityntapysakointi-alue:",
     },
+    {
+        "type": "hgv_street_parking_area",
+        "service_url": "https://matti.vantaa.fi/server2/rest/services/Hosted/Raskaan_liikenteen_sallitut_kadunvarret/"
+        "FeatureServer",
+        "layer_name": "Raskaan liikenteen sallitut kadunvarret MUOKATTAVA",
+        "ocd_id_base": "ocd-division/country:fi/kunta:vantaa/raskaanliikenteen-sallittu-kadunvarsi-alue:",
+    },
 ]
 
 SRC_SRID = 4326

--- a/services/management/commands/update_vantaa_parking_areas.py
+++ b/services/management/commands/update_vantaa_parking_areas.py
@@ -7,7 +7,7 @@ import os
 from time import time
 
 from django.contrib.gis.gdal import CoordTransform, SpatialReference
-from django.contrib.gis.geos import GEOSGeometry, MultiPolygon, Polygon
+from django.contrib.gis.geos import GEOSGeometry, LineString, MultiPolygon, Polygon
 from django.core.management.base import BaseCommand
 from munigeo.models import (
     AdministrativeDivision,
@@ -26,8 +26,32 @@ logger = logging.getLogger("services.management")
 OCD_ID_VANTAA_PARKING_BASE = (
     "ocd-division/country:fi/kunta:vantaa/pysakointipaikka-alue:"
 )
-SRC_SERVICE_URL = "https://matti.vantaa.fi/server2/rest/services/Hosted/Pys%C3%A4k%C3%B6intialueet/FeatureServer"
-SRC_LAYER_NAME = "Pyskintialueet MUOKATTAVA"
+AREA_SERVICE_URL = "https://matti.vantaa.fi/server2/rest/services/Hosted/Pys%C3%A4k%C3%B6intialueet/FeatureServer"
+AREA_LAYER_NAME = "Pyskintialueet MUOKATTAVA"
+AREA_TYPE = "parking_area"
+
+OCD_ID_VANTAA_STREET_PARKING_BASE = (
+    "ocd-division/country:fi/kunta:vantaa/kadunvarsipysakointi-alue:"
+)
+STREET_SERVICE_URL = "https://matti.vantaa.fi/server2/rest/services/Hosted/Kadunvarsipys%C3%A4k%C3%B6inti/FeatureServer"
+STREET_LAYER_NAME = "Kadunvarsipysäköinti MUOKATTAVA"
+STREET_TYPE = "street_parking_area"
+
+DATA_SOURCES = [
+    {
+        "service_url": AREA_SERVICE_URL,
+        "layer_name": AREA_LAYER_NAME,
+        "type": AREA_TYPE,
+        "ocd_id_base": OCD_ID_VANTAA_PARKING_BASE,
+    },
+    {
+        "service_url": STREET_SERVICE_URL,
+        "layer_name": STREET_LAYER_NAME,
+        "type": STREET_TYPE,
+        "ocd_id_base": OCD_ID_VANTAA_STREET_PARKING_BASE,
+    },
+]
+
 SRC_SRID = 4326
 
 PARKING_NAME_TRANSLATIONS = {
@@ -48,6 +72,28 @@ class Command(BaseCommand):
     def handle(self, *args, **options) -> None:
         self.update_parking_areas()
 
+    def transform_line_to_polygon(self, obj):
+        """
+        Transform a LineString to a Polygon or MultiPolygon.
+        """
+        target_srid = (
+            32633  # UTM zone 33N (with UTM we can use meters to buffer the line)
+        )
+        original_spatial_ref = SpatialReference(obj.srid)
+        target_spatial_ref = SpatialReference(target_srid)
+        coord_transform = CoordTransform(original_spatial_ref, target_spatial_ref)
+        transformed_line = obj.transform(coord_transform, clone=True)
+
+        # Buffer the line with 1 meter to create a polygon
+        buffered_line = transformed_line.buffer(1)
+
+        # Transform the buffered geometry back to the original SRID
+        if obj.srid != target_srid:
+            back_transform = CoordTransform(target_spatial_ref, original_spatial_ref)
+            buffered_line.transform(back_transform)
+
+        return buffered_line
+
     def get_multi_geom(self, obj):
         """
         Return the appropriate multi-container for the supplied geometry.
@@ -57,78 +103,100 @@ class Command(BaseCommand):
             return MultiPolygon(obj)
         elif isinstance(obj, (MultiPolygon)):
             return obj
+        elif isinstance(obj, (LineString)):
+            buffered_line = self.transform_line_to_polygon(obj)
+            if isinstance(buffered_line, MultiPolygon):
+                return buffered_line
+            elif isinstance(buffered_line, Polygon):
+                return MultiPolygon([buffered_line])
+            else:
+                raise ValueError("Buffered geometry is not a Polygon or MultiPolygon.")
         else:
             raise Exception(
                 "Unsupported geometry type: {}".format(obj.__class__.__name__)
             )
 
     def update_parking_areas(self):
-        start_time = time()
-        num_parking_areas_updated = 0
-
         src_srs = SpatialReference(SRC_SRID)
         dest_srs = SpatialReference(get_default_srid())
         src_to_dest = CoordTransform(src_srs, dest_srs)
-
         municipality = Municipality.objects.get(name_fi="Vantaa")
-        type = AdministrativeDivisionType.objects.get(type="parking_area")
 
-        service = restapi.FeatureService(SRC_SERVICE_URL)
-        parking_areas = service.layer(SRC_LAYER_NAME)
-        features = parking_areas.query()
+        for data_source in DATA_SOURCES:
+            start_time = time()
+            num_parking_areas_updated = 0
 
-        logger.info("Found {} parking areas for Vantaa".format(features.count))
-        logger.info("Importing parking areas...")
-
-        updated_parking_areas = []
-        for feature in features:
-            geom = self.get_multi_geom(
-                GEOSGeometry(str(feature.get("geometry")), srid=SRC_SRID)
-            )
-            geom.transform(src_to_dest)
-            props = feature.get("properties")
-            origin_id = str(props.get("objectid")) if props.get("objectid") else None
-            if not origin_id:
-                logger.warning("Parking area has no origin ID, skipping")
-                continue
-            name_fi = props.get("tyyppi")
-            defaults = {
-                "name_fi": name_fi,
-                "municipality": municipality,
-                "type": type,
-                "extra": props,
-                "origin_id": origin_id,
-            }
             try:
-                name_en = PARKING_NAME_TRANSLATIONS[name_fi]["en"]
-                name_sv = PARKING_NAME_TRANSLATIONS[name_fi]["sv"]
-                defaults["name_en"] = name_en
-                defaults["name_sv"] = name_sv
-            except KeyError:
-                logger.warning(f"No translation for {name_fi}")
+                division_type = AdministrativeDivisionType.objects.get(
+                    type=data_source["type"]
+                )
+            except AdministrativeDivisionType.DoesNotExist:
+                division_name = (
+                    data_source["layer_name"].replace("MUOKATTAVA", "").strip()
+                )
+                division_type = AdministrativeDivisionType.objects.create(
+                    type=data_source["type"], name=division_name
+                )
 
-            division, _ = AdministrativeDivision.objects.update_or_create(
-                ocd_id=OCD_ID_VANTAA_PARKING_BASE + origin_id,
-                defaults=defaults,
+            service = restapi.FeatureService(data_source["service_url"])
+            parking_areas = service.layer(data_source["layer_name"])
+            features = parking_areas.query()
+
+            readable_name = data_source["type"].replace("_", " ").strip() + "s"
+            logger.info(f"Found {features.count} {readable_name} for Vantaa")
+            logger.info(f"Importing {readable_name}...")
+
+            updated_parking_areas = []
+            for feature in features:
+                geom = self.get_multi_geom(
+                    GEOSGeometry(str(feature.get("geometry")), srid=SRC_SRID)
+                )
+                geom.transform(src_to_dest)
+                props = feature.get("properties")
+                origin_id = (
+                    str(props.get("objectid")) if props.get("objectid") else None
+                )
+                if not origin_id:
+                    logger.warning("Parking area has no origin ID, skipping")
+                    continue
+                name_fi = props.get("tyyppi")
+                defaults = {
+                    "name_fi": name_fi,
+                    "municipality": municipality,
+                    "type": division_type,
+                    "extra": props,
+                    "origin_id": origin_id,
+                }
+                try:
+                    name_en = PARKING_NAME_TRANSLATIONS[name_fi]["en"]
+                    name_sv = PARKING_NAME_TRANSLATIONS[name_fi]["sv"]
+                    defaults["name_en"] = name_en
+                    defaults["name_sv"] = name_sv
+                except KeyError:
+                    logger.warning(f"No translation for {name_fi}")
+
+                division, _ = AdministrativeDivision.objects.update_or_create(
+                    ocd_id=data_source["ocd_id_base"] + origin_id,
+                    defaults=defaults,
+                )
+                AdministrativeDivisionGeometry.objects.update_or_create(
+                    division=division,
+                    defaults={"boundary": geom},
+                )
+                logger.debug("Updated parking area {}".format(division.name_fi))
+                updated_parking_areas.append(division)
+                num_parking_areas_updated += 1
+
+            # Delete parking areas that are no longer in the source data
+            all_parking_areas = AdministrativeDivision.objects.filter(
+                type=division_type, municipality=municipality
             )
-            AdministrativeDivisionGeometry.objects.update_or_create(
-                division=division,
-                defaults={"boundary": geom},
+            removed_parking_areas = all_parking_areas.exclude(
+                id__in=[area.id for area in updated_parking_areas]
             )
-            logger.debug("Updated parking area {}".format(division.name_fi))
-            updated_parking_areas.append(division)
-            num_parking_areas_updated += 1
+            num_parking_areas_deleted = removed_parking_areas.delete()[0]
 
-        # Delete parking areas that are no longer in the source data
-        all_parking_areas = AdministrativeDivision.objects.filter(
-            type=type, municipality=municipality
-        )
-        removed_parking_areas = all_parking_areas.exclude(
-            id__in=[area.id for area in updated_parking_areas]
-        )
-        num_parking_areas_deleted = removed_parking_areas.delete()[0]
-
-        logger.info(
-            f"Import completed. {num_parking_areas_updated} parking areas updated and {num_parking_areas_deleted} deleted "
-            f"in {time() - start_time:.0f} seconds."
-        )
+            logger.info(
+                f"Import completed. {num_parking_areas_updated} {readable_name} updated and {num_parking_areas_deleted}"
+                f" deleted in {time() - start_time:.0f} seconds."
+            )

--- a/services/management/commands/update_vantaa_parking_areas.py
+++ b/services/management/commands/update_vantaa_parking_areas.py
@@ -37,6 +37,13 @@ STREET_SERVICE_URL = "https://matti.vantaa.fi/server2/rest/services/Hosted/Kadun
 STREET_LAYER_NAME = "Kadunvarsipysäköinti MUOKATTAVA"
 STREET_TYPE = "street_parking_area"
 
+OCD_ID_VANTAA_PARK_AND_RIDE_PARKING_BASE = (
+    "ocd-division/country:fi/kunta:vantaa/liityntapysakointi-alue:"
+)
+PARK_AND_RIDE_SERVICE_URL = "https://matti.vantaa.fi/server2/rest/services/Hosted/Liitynt%C3%A4pys%C3%A4k%C3%B6intialueet/FeatureServer"
+PARK_AND_RIDE_LAYER_NAME = "Liityntäpysäköintialueet MUOKATTAVA"
+PARK_AND_RIDE_TYPE = "park_and_ride_area"
+
 DATA_SOURCES = [
     {
         "service_url": AREA_SERVICE_URL,
@@ -49,6 +56,12 @@ DATA_SOURCES = [
         "layer_name": STREET_LAYER_NAME,
         "type": STREET_TYPE,
         "ocd_id_base": OCD_ID_VANTAA_STREET_PARKING_BASE,
+    },
+    {
+        "service_url": PARK_AND_RIDE_SERVICE_URL,
+        "layer_name": PARK_AND_RIDE_LAYER_NAME,
+        "type": PARK_AND_RIDE_TYPE,
+        "ocd_id_base": OCD_ID_VANTAA_PARK_AND_RIDE_PARKING_BASE,
     },
 ]
 
@@ -63,6 +76,7 @@ PARKING_NAME_TRANSLATIONS = {
     "Maksullinen": {"sv": "Avgiftsbelagd", "en": "Paid"},
     "Muu": {"sv": "Något annat", "en": "Other"},
     "Varattu päivisin": {"sv": "Bokas dagtid", "en": "Reserved during the day"},
+    "Liityntäpysäköinti": {"sv": "Pendelparkering", "en": "Park & Ride"},
 }
 
 

--- a/services/tests/data/vantaa_parking_areas.json
+++ b/services/tests/data/vantaa_parking_areas.json
@@ -1,0 +1,94 @@
+{
+  "features": [
+    {
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              25.084374753255055,
+              60.3499294370369
+            ],
+            [
+              25.08408380151095,
+              60.34990982397221
+            ],
+            [
+              25.084089858850913,
+              60.34983805624883
+            ],
+            [
+              25.084383300724973,
+              60.349855193165794
+            ],
+            [
+              25.084374753255055,
+              60.3499294370369
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": 1,
+      "properties": {
+        "aikarajoitus": "30 min",
+        "aikarajoitus_num": null,
+        "aluetunnus": null,
+        "katu": null,
+        "kaupunginosa": null,
+        "kiekkopaikka": "Kyllä",
+        "lisätiedot": null,
+        "objectid": 1,
+        "objectid_1": null,
+        "paikkamäärä": 6,
+        "paikkamääräap": "6 ap",
+        "tyyppi": "Lyhytaikainen",
+        "voimassaoloaika": null
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          [
+            25.049797811943435,
+            60.35260110313705
+          ],
+          [
+            25.049934474444232,
+            60.35248545784165
+          ],
+          [
+            25.05008239193723,
+            60.35239648422703
+          ],
+          [
+            25.050167558514346,
+            60.35234643499014
+          ],
+          [
+            25.05058901570631,
+            60.352171773300924
+          ]
+        ],
+        "type": "LineString"
+      },
+      "id": 2,
+      "properties": {
+        "aikarajoitus": null,
+        "aikarajoitus_num": null,
+        "aluetunnus": null,
+        "katu": null,
+        "kaupunginosa": null,
+        "kiekkopaikka": "Ei",
+        "lisätiedot": null,
+        "objectid": 2,
+        "objectid_1": 2,
+        "paikkamäärä": 8,
+        "paikkamääräap": "8 ap",
+        "tyyppi": "Ei rajoitusta",
+        "voimassaoloaika": null
+      },
+      "type": "Feature"
+    }
+  ]
+}

--- a/services/tests/data/vantaa_parking_areas_null_geometry.json
+++ b/services/tests/data/vantaa_parking_areas_null_geometry.json
@@ -1,0 +1,24 @@
+{
+  "features": [
+    {
+      "geometry": null,
+      "id": 3,
+      "properties": {
+        "aikarajoitus": "30 min",
+        "aikarajoitus_num": null,
+        "aluetunnus": null,
+        "katu": null,
+        "kaupunginosa": null,
+        "kiekkopaikka": "Kyllä",
+        "lisätiedot": null,
+        "objectid": 3,
+        "objectid_1": null,
+        "paikkamäärä": 6,
+        "paikkamääräap": "6 ap",
+        "tyyppi": "Lyhytaikainen",
+        "voimassaoloaika": null
+      },
+      "type": "Feature"
+    }
+  ]
+}

--- a/services/tests/test_update_vantaa_parking_areas.py
+++ b/services/tests/test_update_vantaa_parking_areas.py
@@ -1,0 +1,104 @@
+import json
+from unittest.mock import patch
+
+import pytest
+from django.contrib.gis.geos import MultiPolygon
+from django.core.management import call_command
+from munigeo.models import (
+    AdministrativeDivision,
+    AdministrativeDivisionType,
+    Municipality,
+)
+
+
+def get_mock_data():
+    file_path = "services/tests/data/vantaa_parking_areas.json"
+    with open(file_path, "r") as json_file:
+        contents = json.load(json_file)
+    return contents.get("features")
+
+
+@pytest.mark.django_db
+@patch(
+    "services.management.commands.update_vantaa_parking_areas.DATA_SOURCES",
+    [
+        {
+            "type": "parking_area",
+            "service_url": "https://url",
+            "layer_name": "Pysäköintialueet MUOKATTAVA",
+            "ocd_id_base": "ocd-division/country:fi/kunta:vantaa/pysakointipaikka-alue:",
+        }
+    ],
+)
+@patch("restapi.FeatureService")
+def test_update_parking_areas(mock_feature_service):
+    # Mock the FeatureService and its layer and features
+    mock_layer_instance = mock_feature_service.return_value.layer.return_value
+    mock_layer_instance.query.return_value = get_mock_data()
+
+    municipality = Municipality.objects.create(id="vantaa", name="Vantaa")
+    division_type = AdministrativeDivisionType.objects.create(type="parking_area")
+
+    assert AdministrativeDivision.objects.count() == 0
+
+    call_command("update_vantaa_parking_areas")
+
+    obj_1 = AdministrativeDivision.objects.get(origin_id=1)
+    obj_2 = AdministrativeDivision.objects.get(origin_id=2)
+
+    assert AdministrativeDivision.objects.count() == 2
+
+    assert obj_1.name_fi == "Lyhytaikainen"
+    assert obj_1.type == division_type
+    assert obj_1.municipality == municipality
+    assert type(obj_1.geometry.boundary) is MultiPolygon
+
+    assert obj_2.name_fi == "Ei rajoitusta"
+    assert obj_2.type == division_type
+    assert obj_2.municipality == municipality
+    assert type(obj_2.geometry.boundary) is MultiPolygon
+
+
+@pytest.mark.django_db
+@patch(
+    "services.management.commands.update_vantaa_parking_areas.DATA_SOURCES",
+    [
+        {
+            "type": "parking_area",
+            "service_url": "https://url",
+            "layer_name": "Pysäköintialueet MUOKATTAVA",
+            "ocd_id_base": "ocd-division/country:fi/kunta:vantaa/pysakointipaikka-alue:",
+        }
+    ],
+)
+@patch("restapi.FeatureService")
+def test_delete_removed_parking_areas(mock_feature_service):
+    mock_layer_instance = mock_feature_service.return_value.layer.return_value
+    mock_layer_instance.query.return_value = get_mock_data()
+
+    municipality = Municipality.objects.create(id="vantaa", name="Vantaa")
+    division_type = AdministrativeDivisionType.objects.create(type="parking_area")
+
+    call_command("update_vantaa_parking_areas")
+
+    # Add a parking area that is not in the source data
+    AdministrativeDivision.objects.create(
+        origin_id="3", type=division_type, municipality=municipality
+    )
+
+    assert (
+        AdministrativeDivision.objects.filter(
+            type=division_type, municipality=municipality
+        ).count()
+        == 3
+    )
+
+    call_command("update_vantaa_parking_areas")
+
+    assert (
+        AdministrativeDivision.objects.filter(
+            type=division_type, municipality=municipality
+        ).count()
+        == 2
+    )
+    assert not AdministrativeDivision.objects.filter(origin_id="3").exists()


### PR DESCRIPTION
## Description

Add several new data sources to Vantaa parking data import.

## Context
[Refs](https://trello.com/c/okKjFrjB/1503-vantaan-kadunvarsipys%C3%A4k%C3%B6inti-palvelukarttaan)

## How Has This Been Tested?

Imported the data locally and added an unit test with a mock data.
