### PR TITLE
Change ubuntu image source to ECR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Using Ubuntu base for access to GDAL PPA
-FROM ubuntu:22.04
+FROM public.ecr.aws/ubuntu/ubuntu:22.04
 WORKDIR /smbackend
 
 # tzdata installation requires settings frontend


### PR DESCRIPTION
## Description

Change the ubuntu image source to Amazon ECR to avoid hitting the Docker Hub pull rate limit.

## Context

[Refs](https://trello.com/c/EB2AQhjj/1586-vaihtoehtoja-dockerhubille)

## How Has This Been Tested?

Build tested locally.
