### PR TITLE
Change error level to warning in department import & in lipas 3D import

### DIFF
--- a/services/management/commands/lipas_import_3d.py
+++ b/services/management/commands/lipas_import_3d.py
@@ -30,7 +30,7 @@ class Command(lipas_import.Command):
                 unit.geometry_3d = geometry
                 unit.save()
             else:
-                logger.error(
+                logger.warning(
                     f"Failed to save unit {unit.name_fi} because of a missing z coordinate.",
                 )
 

--- a/services/management/commands/services_import/departments.py
+++ b/services/management/commands/services_import/departments.py
@@ -48,7 +48,7 @@ def import_departments(noop=False, logger=None, fetch_resource=pk_get):
                     parent = Department.objects.get(uuid=parent_id)
                     obj.parent_id = parent.id
                 except Department.DoesNotExist:
-                    logger and logger.error(
+                    logger and logger.warning(
                         "Department import: no parent with uuid {} found for {}".format(
                             parent_id, d["id"]
                         )


### PR DESCRIPTION
## Description

- Change the error level to warning when parent department in not found.
- Change the error level from error to warning in lipas import 3D when the unit is not saved due to a missing z coordinate.

## Context

[Refs](https://trello.com/c/LSzEVcqx/1591-department-import-p%C3%A4ivitet%C3%A4%C3%A4n-virhe-varoitustasoiseksi-lokiviestiksi) & [Refs](https://trello.com/c/twazibBz/1590-lipas-import-p%C3%A4ivitet%C3%A4%C3%A4n-z-koordinaatin-puuttumisvirheet-varoitustasoisiksi-lokiviesteiksi)

