### PR TITLE
Search: handle department & municipality serialization in unit results

### DIFF
--- a/services/search/api.py
+++ b/services/search/api.py
@@ -193,6 +193,12 @@ class SearchSerializer(serializers.Serializer):
                     representation["connections"] = UnitConnectionSerializer(
                         obj.connections, many=True
                     ).data
+                elif "department" in include_field:
+                    representation["department"] = DepartmentSerializer(
+                        obj.department
+                    ).data
+                elif "municipality" in include_field:
+                    representation["municipality"] = obj.municipality.id
                 else:
                     if hasattr(obj, include_field):
                         representation[include_field] = getattr(


### PR DESCRIPTION
## Description

The issue was noticed when using `include=unit.department` in search raised _"Object of type Department is not JSON serializable"_ errors. Add department and municipality serialization to the search results to fix the issue.

## Context

[Refs](https://trello.com/c/srahvMzf/1589-hakurajapinta-typeerror)
