### PR TITLE
Search: handle vertical lines in search query

### DIFF
--- a/services/search/api.py
+++ b/services/search/api.py
@@ -466,6 +466,10 @@ class SearchViewSet(GenericAPIView):
 
         config_language = LANGUAGES[language_short]
         search_query_str = None  # Used in the raw sql
+        # Replace multiple consecutive vertical bars with a single vertical bar to be used as an OR operator.
+        q_val = re.sub(r"\|+", "|", q_val)
+        # Remove vertical bars that are not between words to avoid errors in the query.
+        q_val = re.sub(r"(?<!\w)\|+|\|+(?!\w)", "", q_val)
         # Build conditional query string that is used in the SQL query.
         # split by "," or whitespace
         q_vals = re.split(r",\s+|\s+", q_val)


### PR DESCRIPTION
## Description

Vertical lines are meant to be used as OR operators in the search. Remove vertical lines that are not used as meant to avoid the search breaking completely.

## Context

[Refs](https://trello.com/c/YqgdsPyf/1588-hakurajapinta-unicodeerror)

## How Has This Been Tested?

Tested locally with the cases that caused the issue and added unit tests.

