### PR TITLE
Add bbox filtering to search 

### DIFF
--- a/services/api.py
+++ b/services/api.py
@@ -991,6 +991,7 @@ class KmlRenderer(renderers.BaseRenderer):
         LEVEL_PARAMETER,
         UNIT_GEOMETRY_PARAMETER,
         UNIT_GEOMETRY_3D_PARAMETER,
+        BBOX_PARAMETER,
     ]
 )
 class UnitViewSet(

--- a/services/search/tests/conftest.py
+++ b/services/search/tests/conftest.py
@@ -96,6 +96,7 @@ def units(
         last_modified_time=now(),
         municipality=municipality,
         department=department,
+        location=Point(24.941387, 60.17103, srid=4326),  # Helsinki center
     )
     # Add service Halli
     unit.services.add(4)

--- a/services/search/tests/test_api.py
+++ b/services/search/tests/test_api.py
@@ -264,3 +264,23 @@ def test_search_with_vertical_bar_in_query(api_client, units):
     url = reverse("search") + "?q=|terveysasema||''||'"
     response = api_client.get(url)
     assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_search_with_bbox_parameter(api_client, units):
+    """
+    When bbox parameter is given, only units within the bounding box should be returned.
+    """
+    url = reverse("search") + "?q=halli&type=unit"
+    response = api_client.get(url)
+    results = response.json()["results"]
+    assert len(results) == 3
+
+    url = (
+        reverse("search")
+        + "?q=halli&type=unit&bbox=24.93545,60.16952,24.95190,60.17800&bbox_srid=4326"
+    )
+    response = api_client.get(url)
+    results = response.json()["results"]
+    assert len(results) == 1
+    assert results[0]["name"]["fi"] == "Jäähalli"


### PR DESCRIPTION
## Description

Add possibility to filter search results by bounding box. This is for when only results in given area are wanted.

Also add missing bbox parameter to unit API parameter.

## Context

[Refs](https://trello.com/c/05wXrbKK/1460-upotuksen-aluerajaus-ongelma-n%C3%A4ytt%C3%A4%C3%A4-zoomattaessa-kaikki)

## How Has This Been Tested?

Tested locally with different searches and added an unit test.
