### PR TITLE
Fix Vantaa population forecast import

### DIFF
--- a/services/management/commands/statistical_queries/vantaa_population_forecast.json
+++ b/services/management/commands/statistical_queries/vantaa_population_forecast.json
@@ -100,7 +100,7 @@
       "selection": {
         "filter": "item",
         "values": [
-          "7"
+          "8"
         ]
       }
     },


### PR DESCRIPTION
## Description

The expected json query had been changed in the Vantaa population forecast and the import was giving status code 400. Fix the query by checking the current format in https://stat.hel.fi/pxweb/fi/Aluesarjat/Aluesarjat__vrm__vaenn__pksoa/C01VANS_Vaestoennuste.px/

## Context

[Refs](https://trello.com/c/bTItB06w/1605-v%C3%A4est%C3%B6tietojen-importteri-antaa-virhett%C3%A4)

## How Has This Been Tested?

Import was run locally after the fix.
