### PR TITLE
Search: handle geometry serialization in unit results

### DIFF
--- a/services/search/api.py
+++ b/services/search/api.py
@@ -205,6 +205,16 @@ class SearchSerializer(serializers.Serializer):
                     ).data
                 elif "municipality" in include_field:
                     representation["municipality"] = obj.municipality.id
+                elif "geometry_3d" in include_field:
+                    if obj.geometry_3d:
+                        representation["geometry_3d"] = munigeo_api.geom_to_json(
+                            obj.geometry_3d, DEFAULT_SRS
+                        )
+                elif "geometry" in include_field:
+                    if obj.geometry:
+                        representation["geometry"] = munigeo_api.geom_to_json(
+                            obj.geometry, DEFAULT_SRS
+                        )
                 else:
                     if hasattr(obj, include_field):
                         representation[include_field] = getattr(


### PR DESCRIPTION
## Description

The issue was noticed when using `include=unit.geometry` in search raised "Object of type MultiLineString is not JSON serializable" errors. Add geometry and geometry_3d serialization to the search results to fix the issue.

## Context

[Refs](https://trello.com/c/PJieWKr7/1611-search-rajapinta-includeunitgeometry-antaa-virhett%C3%A4)
