### PR TITLE
Add heightprofilegeom parameter to unit API

### DIFF
--- a/services/api.py
+++ b/services/api.py
@@ -77,6 +77,7 @@ from services.open_api_parameters import (
 )
 from services.utils import check_valid_concrete_field, strtobool
 from services.utils.geocode_address import geocode_address
+from services.utils.height_profile_geom import multilinestring_to_linestring_features
 
 if settings.REST_FRAMEWORK and settings.REST_FRAMEWORK["DEFAULT_RENDERER_CLASSES"]:
     DEFAULT_RENDERERS = [
@@ -912,6 +913,13 @@ class UnitSerializer(
                 ret["geometry_3d"] = munigeo_api.geom_to_json(geom, self.srs)
         elif "geometry_3d" in ret:
             del ret["geometry_3d"]
+
+        if qparams.get("heightprofilegeom", "").lower() in ("true", "1"):
+            if obj.geometry_3d:
+                geometry = munigeo_api.geom_to_json(obj.geometry_3d, self.srs)
+                ret["height_profile_geom"] = multilinestring_to_linestring_features(
+                    geometry.get("coordinates")
+                )
 
         if qparams.get("accessibility_description", "").lower() in ("true", "1"):
             ret["accessibility_description"] = shortcomings.accessibility_description

--- a/services/utils/height_profile_geom.py
+++ b/services/utils/height_profile_geom.py
@@ -1,0 +1,23 @@
+def multilinestring_to_linestring_features(coords):
+    if coords is None:
+        return None
+
+    return {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": {"type": "LineString", "coordinates": line},
+                "properties": {
+                    "attributeType": "flat"
+                },  # TODO: Add support for other types
+            }
+            for line in coords
+        ],
+        "properties": {
+            "summary": "Height",
+            "label": "Height profile",
+            "label_fi": "Korkeusprofiili",
+            "label_sv": "Höjdprofil",
+        },
+    }


### PR DESCRIPTION
## Description

Add `heightprofilegeom` parameter to unit API to return the height profile as LineString features. This will be used by the frontend in the evaluation tool.

## Context

[Refs](https://trello.com/c/d2TDzuFd/1615-lis%C3%A4%C3%A4-heightprofilegeom-parametri-unit-rajapintaan)