### PR TITLE
Lipas import: fix  'object has no attribute 'merged' error

### DIFF
--- a/services/management/commands/lipas_import.py
+++ b/services/management/commands/lipas_import.py
@@ -189,7 +189,7 @@ class Command(BaseCommand):
                 if isinstance(line_geometry, LineString):
                     line_geometry = MultiLineString([line_geometry])
                 unit.geometry = line_geometry
-            except TypeError as e:
+            except (AttributeError, TypeError) as e:
                 logger.warning(
                     f"Failed to merge geometry for unit {unit.name_fi}: {e}",
                 )


### PR DESCRIPTION
## Description

Handle AttributeError in addition to TypeError when saving geometries in lipas import.

## Context

[Refs](https://trello.com/c/kzhZWkfR/1626-multipolygon-object-has-no-attribute-merged)