### PR TITLE
Rework search query building

### DIFF
--- a/services/search/api.py
+++ b/services/search/api.py
@@ -1,17 +1,17 @@
 """
-Brief explanation how full text search is implemented in the smbacked.
+Brief explanation how full text search is implemented in the smbackend.
 - Currently search is performed to following models, Unit, Service,
 munigeo_Address, munigeo_Administrative_division.
-- For every model that is include in the search a search column is added
+- For every model that is included in the search a search column is added
 for every language of type SearchVector. These are also defined as a Gindex.
  The models that are searched also implements a function called get_search_column_indexing
   where the name, configuration(language) and weight of the columns that will be indexed
   are defined. This function is used by the indexing script and signals when
   the search_column is populated.
 - A view called search_view is created and it contains the search_columns of the models
-and a couple auxilary columns: id. type_name and name. This view is created by a
+and a couple auxiliary columns: id. type_name and name. This view is created by a
 raw SQL migration 008X_create_search_view.py.
-- The search if performed by quering the views search_columns.
+- The search if performed by querying the views search_columns.
 - For models included in the search a post_save signal is connected and the
   search_column is updated when they are saved.
 - The search_columns can be manually updated with  the index_search_columns
@@ -303,7 +303,7 @@ def build_search_query(query: str):
         OpenApiParameter(
             name="use_websearch",
             location=OpenApiParameter.QUERY,
-            description="Use websearch_to_tsquery instead of to_tsquery if exlusion rules are defined for the search.",
+            description="Use websearch_to_tsquery instead of to_tsquery if exclusion rules are defined for the search.",
             required=False,
             type=bool,
         ),

--- a/services/search/api.py
+++ b/services/search/api.py
@@ -531,7 +531,7 @@ class SearchViewSet(GenericAPIView):
         try:
             cursor.execute(sql, [search_query_str])
         except Exception as e:
-            logger.error(f"Error in search query: {e}")
+            logger.error(f"Error in search query: {e}", exc_info=e)
             raise ParseError("Search query failed.")
         # Note, fetchall() consumes the results and once called returns None.
         all_results = cursor.fetchall()

--- a/services/search/tests/test_api.py
+++ b/services/search/tests/test_api.py
@@ -1,6 +1,8 @@
 import pytest
 from rest_framework.reverse import reverse
 
+from services.search.api import build_search_query
+
 
 @pytest.mark.django_db
 def test_search(
@@ -194,6 +196,7 @@ def test_search_service_order(api_client, units, services):
         "123",  # Test number
         "halli.museo",  # Test .
         "halli's",  # Test '
+        "halli,museo",  # Test ,
     ],
 )
 @pytest.mark.django_db
@@ -210,32 +213,104 @@ def test_search_input_query_disallowed_characters(api_client):
     assert response.status_code == 400
     assert (
         response.json()["detail"]
-        == "Invalid search terms, only letters, numbers, spaces and .'+-&| allowed."
+        == "Invalid search terms, only letters, numbers, spaces and .,'+-&| allowed."
     )
 
 
 @pytest.mark.django_db
 def test_search_with_vertical_bar_in_query(api_client, units):
-    # Test that a single vertical bar in query is treated as OR operator
-    url = reverse("search") + "?q=terveysasema|museo&type=unit"
-    response = api_client.get(url)
-    assert response.status_code == 200
-    assert len(response.json()["results"]) == 2
-    assert response.json()["results"][0]["name"]["fi"] == "Terveysasema"
-    assert response.json()["results"][1]["name"]["fi"] == "Biologinen museo"
-
-    # Test that multiple vertical bars in query are treated as OR operators
-    url = reverse("search") + "?q=terveysasema||museo&type=unit"
-    response = api_client.get(url)
-    assert response.status_code == 200
-    assert len(response.json()["results"]) == 2
-    assert response.json()["results"][0]["name"]["fi"] == "Terveysasema"
-    assert response.json()["results"][1]["name"]["fi"] == "Biologinen museo"
-
     # Test that a vertical bars that are not between search terms do not cause an error
     url = reverse("search") + "?q=|terveysasema||''||'"
     response = api_client.get(url)
-    assert response.status_code == 200
+    assert response.status_code == 200, f"{response} {response.json()}"
+
+
+@pytest.mark.parametrize(
+    "query,expected",
+    [
+        # Single-operand expression
+        ("a", "a:*"),
+        ("|a|", "a:*"),
+        ("&a&", "a:*"),
+        (" a ", "a:*"),
+        ("& |a  || &|&    &&", "a:*"),
+        # Two-operand expressions with AND operator
+        ("a b", "a:* & b:*"),
+        ("a,b", "a:* & b:*"),
+        ("a, b", "a:* & b:*"),
+        ("a,,, , ,, , , , ,   ,  ,,  ,        b", "a:* & b:*"),
+        ("a & b", "a:* & b:*"),
+        ("a& b", "a:* & b:*"),
+        ("a &b", "a:* & b:*"),
+        ("a&b", "a:* & b:*"),
+        ("a&&&&&&&&&&&&&b", "a:* & b:*"),
+        ("a  , &&&&&&&,    &  ,, & & & & &&&&& , , ,,,,      b", "a:* & b:*"),
+        # Two-operand expressions with OR operator
+        ("a | b", "a:* | b:*"),
+        ("a | b", "a:* | b:*"),
+        ("a| b", "a:* | b:*"),
+        ("a |b", "a:* | b:*"),
+        ("a|b", "a:* | b:*"),
+        ("a|||||||||||||b", "a:* | b:*"),
+        ("a ||| |||    ||  | ||| b", "a:* | b:*"),
+        # >=3 operands
+        ("a | b | c", "a:* | b:* | c:*"),
+        ("a, b, c", "a:* & b:* & c:*"),
+        ("a & b c, d", "a:* & b:* & c:* & d:*"),
+        # Mixed OR and AND operators
+        ("a, b | c, d", "a:* & b:* | c:* & d:*"),
+        ("a, &&& , & b || || |||| |c,,,, d", "a:* & b:* | c:* & d:*"),
+        # Expression with repeating single-quotes
+        ("','','''',a,b'c,d''e,f'''g,','','''", "a:* & b'c:* & d''e:* & f'''g:*"),
+    ],
+)
+def test_build_search_query(query, expected):
+    assert build_search_query(query) == expected
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "palloilu, halli",
+        "palloilu,halli",
+        "palloilu,     halli",
+        "palloilu,,,,,,halli",
+        "palloilu halli",
+        "palloilu    halli",
+        ",palloilu,halli",
+        "palloilu,halli,,",
+    ],
+)
+@pytest.mark.django_db
+def test_search_input_and_operator(api_client, units, query):
+    url = reverse("search")
+    response = api_client.get(url, {"q": query, "type": "unit"})
+    assert response.status_code == 200, f"{response} {response.json()}"
+    assert len(response.json()["results"]) == 1
+    assert response.json()["results"][0]["name"]["fi"] == "Palloiluhalli"
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "terveysasema|museo",
+        "terveysasema | museo",
+        "terveysasema |museo",
+        "terveysasema| museo",
+        "      terveysasema     |      museo  ",
+        "terveysasema||museo",
+        "terveysasema|||||||||museo",
+        "|||terveysasema|museo||",
+    ],
+)
+@pytest.mark.django_db
+def test_search_input_or_operator(api_client, units, query):
+    url = reverse("search")
+    response = api_client.get(url, {"q": query, "type": "unit"})
+    assert response.status_code == 200, f"{response} {response.json()}"
+    assert len(response.json()["results"]) == 2
+    assert response.json()["results"][0]["name"]["fi"] == "Terveysasema"
+    assert response.json()["results"][1]["name"]["fi"] == "Biologinen museo"
 
 
 @pytest.mark.django_db

--- a/services/search/tests/test_api.py
+++ b/services/search/tests/test_api.py
@@ -179,62 +179,34 @@ def test_search_service_order(api_client, units, services):
     assert results[2]["unit_count"]["total"] == 0
 
 
+@pytest.mark.parametrize(
+    "query",
+    [
+        "halli|museo",  # Test |
+        "halli&museo",  # Test &
+        "linja-auto",  # Test -
+        "Keskustakirjasto Oodi",  # Test whitespace
+        "Keskustakirjasto+Oodi",  # Test +
+        # Test ääkköset
+        "lääkäri",
+        "röntgen",
+        "åbo",
+        "123",  # Test number
+        "halli.museo",  # Test .
+        "halli's",  # Test '
+    ],
+)
 @pytest.mark.django_db
-def test_search_input_query_validation(api_client):
-    # Test that | is allowed in query
-    url = reverse("search") + "?q=halli|museo"
-    response = api_client.get(url)
+def test_search_input_query_valid_characters(api_client, query):
+    url = reverse("search")
+    response = api_client.get(url, {"q": query})
     assert response.status_code == 200
 
-    # Test that & is allowed in query
-    url = reverse("search") + "?q=halli&museo"
-    response = api_client.get(url)
-    assert response.status_code == 200
 
-    # Test that - is allowed in query
-    url = reverse("search") + "?q=linja-auto"
-    response = api_client.get(url)
-    assert response.status_code == 200
-
-    # Test that " " is allowed in query
-    url = reverse("search") + "?q=Keskustakirjasto Oodi"
-    response = api_client.get(url)
-    assert response.status_code == 200
-
-    # Test that + is allowed in query
-    url = reverse("search") + "?q=Keskustakirjasto+Oodi"
-    response = api_client.get(url)
-    assert response.status_code == 200
-
-    # Test that "ääkköset" are allowed in query
-    url = reverse("search") + "?q=lääkäri"
-    response = api_client.get(url)
-    assert response.status_code == 200
-    url = reverse("search") + "?q=röntgen"
-    response = api_client.get(url)
-    assert response.status_code == 200
-    url = reverse("search") + "?q=åbo"
-    response = api_client.get(url)
-    assert response.status_code == 200
-
-    # Test that numbers are allowed in query
-    url = reverse("search") + "?q=123"
-    response = api_client.get(url)
-    assert response.status_code == 200
-
-    # Test that . is allowed in query
-    url = reverse("search") + "?q=halli.museo"
-    response = api_client.get(url)
-    assert response.status_code == 200
-
-    # Test that ' is allowed in query
-    url = reverse("search") + "?q=halli's"
-    response = api_client.get(url)
-    assert response.status_code == 200
-
-    # Test that special characters are not allowed in query
-    url = reverse("search") + "?q=halli("
-    response = api_client.get(url)
+@pytest.mark.django_db
+def test_search_input_query_disallowed_characters(api_client):
+    url = reverse("search")
+    response = api_client.get(url, {"q": "halli("})
     assert response.status_code == 400
     assert (
         response.json()["detail"]


### PR DESCRIPTION
## Description

This PR fixes several issues with the search:

- Add traceback info for the failed SQL query
- Use APIClient's `data` parameter for query parameters instead of manually inserting them in the URL
  - By using the `data` parameter, the query parameters get correctly encoded, e.g. `&` becomes `%26`
  - If the query parameters are typed manually as part of the URL, they need to be encoded, e.g. `foo&bar` needs to be `foo%26bar`, otherwise it's interpreted as a separator
- Accept commas in queries (as stated in the API documentation)
- Rework search query building
  - Separate into its own method
  - Treat pipe operator as an OR operator and not an AND operator
  - Split the query to OR and AND operators
  - Strip operands with single-quotes only (e.g. `''''' | foo` becomes `foo:*`)
  - Treat commas, whitespace and ampersands as AND operators

Known issues:
Single-quotes might mess with the query, but the original implementation didn't really deal with them either, so left it as it is (aside from fixing some of the errors caused by `'`s.)

## Context

Using `&` in a search query causes an error. Found other issues while investigating this, e.g. some part of the code was unreachable, `foo|bar` was interpreted as is (becoming `foo|bar:*` in the SQL), but `foo| bar`, `foo |bar` and `foo | bar` would turn into ANDs (becoming `foo & bar:*`)

[PL-38](https://helsinkisolutionoffice.atlassian.net/browse/PL-38)

## How Has This Been Tested?

Unit tests.

## Manual Testing Instructions for Reviewers

You can test it through the API with different queries, e.g. http://localhost:8000/v2/search/?q=a%26b
<!-- Make it easy for reviewers to test your changes by providing instructions -->



[PL-38]: https://helsinkisolutionoffice.atlassian.net/browse/PL-38?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ