### PR TITLE
chore: don't restart container automatically on reboot

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -21,7 +21,7 @@ services:
       - .:/app
     ports:
       - "8000:8000"
-    restart: on-failure
+    restart: unless-stopped
     depends_on:
       - postgres
     container_name: servicemap-backend


### PR DESCRIPTION
This PR makes sure the stopped container doesn't automatically start when developer machine is restarted (and docker service is started).