### PR TITLE
chore: add default value to entrypoint DATABASE_HOST

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 
 # Wait for the database to be available
 if [ -z "$SKIP_DATABASE_CHECK" ] || [ "$SKIP_DATABASE_CHECK" = "0" ]; then
-  until nc -z -v -w30 "$DATABASE_HOST" "${DATABASE_PORT:-5432}"
+  until nc -z -v -w30 "${DATABASE_HOST:-postgres}" "${DATABASE_PORT:-5432}"
   do
     echo "Waiting for postgres database connection..."
     sleep 1


### PR DESCRIPTION
Running container locally gave some error when checking the database connection without proper value set.

This adds default value to nc db check for the database.


