### PR TITLE
Return an empty list if no units are found for an administrative division, verify school districts after import

### DIFF
--- a/scripts/run_imports.sh
+++ b/scripts/run_imports.sh
@@ -32,6 +32,7 @@ function stage_2 {
     ./manage.py services_import_v4 unit_properties
     ./manage.py update_helsinki_school_districts
     ./manage.py update_helsinki_preschool_districts
+    ./manage.py verify_school_districts
 }
 
 function stage_3 {

--- a/services/api.py
+++ b/services/api.py
@@ -1394,8 +1394,8 @@ class AdministrativeDivisionSerializer(munigeo_api.AdministrativeDivisionSeriali
 
         query_params = self.context["request"].query_params
         unit_include = query_params.get("unit_include", None)
-        service_point_id = ret["service_point_id"]
-        if service_point_id and unit_include:
+
+        if (service_point_id := ret["service_point_id"]) and unit_include:
             try:
                 unit = Unit.objects.get(id=service_point_id)
             except Unit.DoesNotExist:
@@ -1408,18 +1408,12 @@ class AdministrativeDivisionSerializer(munigeo_api.AdministrativeDivisionSeriali
                 ser = UnitSerializer(unit, context={"only": unit_include.split(",")})
                 ret["unit"] = ser.data
 
-        unit_ids = ret["units"]
-        if unit_ids and unit_include:
+        if (unit_ids := ret["units"]) and unit_include:
             units = Unit.objects.filter(id__in=unit_ids)
-            if units:
-                units_data = []
-                for unit in units:
-                    units_data.append(
-                        UnitSerializer(
-                            unit, context={"only": unit_include.split(",")}
-                        ).data
-                    )
-                ret["units"] = units_data
+            ret["units"] = [
+                UnitSerializer(unit, context={"only": unit_include.split(",")}).data
+                for unit in units
+            ]
 
         include_fields = query_params.get("include", [])
         if "centroid" in include_fields and obj.geometry:

--- a/services/tests/test_administrative_division_view_set_api.py
+++ b/services/tests/test_administrative_division_view_set_api.py
@@ -1,7 +1,8 @@
 import pytest
 from django.conf import settings
-from django.contrib.gis.geos import MultiPolygon, Polygon
+from django.contrib.gis.geos import MultiPolygon, Point, Polygon
 from django.urls import reverse
+from django.utils import timezone
 from munigeo.models import (
     AdministrativeDivision,
     AdministrativeDivisionGeometry,
@@ -11,6 +12,7 @@ from munigeo.models import (
 from rest_framework.test import APIClient
 
 from services.api import make_muni_ocd_id
+from services.models import Unit
 from services.tests.utils import get
 
 
@@ -47,6 +49,52 @@ def create_test_area():
 
 
 @pytest.fixture
+def municipality():
+    """
+    Fixture to create a sample municipality for testing.
+    """
+    return Municipality.objects.create(id="helsinki", name="Helsinki")
+
+
+@pytest.fixture
+def administrative_division_type():
+    """
+    Fixture to create a sample administrative division type for testing.
+    """
+    return AdministrativeDivisionType.objects.create(type="muni")
+
+
+@pytest.fixture
+def administrative_division(administrative_division_type, municipality):
+    """
+    Fixture to create a sample administrative division for testing.
+    """
+    return AdministrativeDivision.objects.create(
+        type=administrative_division_type,
+        name="Test Division",
+        ocd_id="ocd-division/test-muni/test-division",
+        municipality=municipality,
+    )
+
+
+@pytest.fixture
+def unit():
+    """
+    Fixture to create a sample unit associated with an administrative division.
+    """
+    unit = Unit.objects.create(
+        id=123,
+        name="Test Unit",
+        location=Point(60.1709, 24.9375, srid=4326),  # Helsinki center
+        public=True,
+        is_active=True,
+        last_modified_time=timezone.now(),
+    )
+
+    return unit
+
+
+@pytest.fixture
 def api_client():
     return APIClient()
 
@@ -57,6 +105,68 @@ def test_get_administrative_division_list(api_client):
     response = get(api_client, reverse("administrativedivision-list"))
     assert response.status_code == 200
     assert response.data["count"] == 3
+
+
+@pytest.mark.django_db
+def test_get_administrative_division_detail(api_client, administrative_division):
+    response = get(
+        api_client,
+        reverse("administrativedivision-detail", args=[administrative_division.id]),
+    )
+
+    assert response.status_code == 200
+    assert response.data["name"]["fi"] == "Test Division"
+    assert response.data["ocd_id"] == "ocd-division/test-muni/test-division"
+
+
+@pytest.mark.django_db
+def test_get_units_in_division(api_client, administrative_division, unit):
+    administrative_division.units = [unit.id]
+    administrative_division.save()
+
+    response = get(
+        api_client,
+        reverse("administrativedivision-detail", args=[administrative_division.id]),
+        data={"unit_include": "name"},
+    )
+
+    assert response.status_code == 200
+    assert "units" in response.data
+    assert len(response.data["units"]) == 1
+    assert response.data["units"][0]["name"]["fi"] == "Test Unit"
+
+
+@pytest.mark.django_db
+def test_units_is_empty_if_no_units_found(api_client, administrative_division, unit):
+    administrative_division.units = [98765]  # Non-existent unit ID
+    administrative_division.save()
+
+    response = get(
+        api_client,
+        reverse("administrativedivision-detail", args=[administrative_division.id]),
+        data={"unit_include": "name"},
+    )
+
+    assert response.status_code == 200
+    assert "units" in response.data
+    assert response.data["units"] == []
+
+
+@pytest.mark.django_db
+def test_get_unit_in_division(api_client, administrative_division, unit):
+    administrative_division.service_point_id = str(unit.id)
+    administrative_division.save()
+
+    response = get(
+        api_client,
+        reverse("administrativedivision-detail", args=[administrative_division.id]),
+        data={"unit_include": "name"},
+    )
+
+    assert response.status_code == 200
+    assert response.data["service_point_id"] == str(unit.id)
+    assert "unit" in response.data
+    assert response.data["unit"]["name"]["fi"] == "Test Unit"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Some of the school districts have units that do not actually exist. This causes some problems with the front-end, since the current implementation returns the unit ids instead of the unit objects if it cannot find any units. This PR changes the implementation to return an empty list instead. 

Also use an existing command for verifying the school districts after performing the import.

Refs: PL-114