### PR TITLE
deps: downgrade urllib3

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,5 +1,5 @@
 -c requirements.txt
-urllib3<3
+urllib3<2  # NOTE: As of django-munigeo 0.2.88, urllib3 2.x is not supported.
 ipython
 jedi
 parso

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ build==1.2.2.post1
     # via pip-tools
 certifi==2024.8.30
     # via
-    #   -c requirements.txt
+    #   -c /home/danipran/code/smbackend/requirements.txt
     #   requests
 cffi==1.17.1
     # via
@@ -18,7 +18,7 @@ cffi==1.17.1
     #   pynacl
 charset-normalizer==3.4.0
     # via
-    #   -c requirements.txt
+    #   -c /home/danipran/code/smbackend/requirements.txt
     #   requests
 click==8.1.7
     # via pip-tools
@@ -34,7 +34,7 @@ executing==2.1.0
     # via stack-data
 idna==3.10
     # via
-    #   -c requirements.txt
+    #   -c /home/danipran/code/smbackend/requirements.txt
     #   requests
 iniconfig==2.0.0
     # via pytest
@@ -90,7 +90,7 @@ pytest-django==4.9.0
     # via -r requirements-dev.in
 requests==2.32.4
     # via
-    #   -c requirements.txt
+    #   -c /home/danipran/code/smbackend/requirements.txt
     #   pygithub
     #   requests-mock
 requests-mock==1.12.1
@@ -99,7 +99,7 @@ ruff==0.9.4
     # via -r requirements-dev.in
 six==1.16.0
     # via
-    #   -c requirements.txt
+    #   -c /home/danipran/code/smbackend/requirements.txt
     #   asttokens
 stack-data==0.6.3
     # via ipython
@@ -109,11 +109,11 @@ traitlets==5.14.3
     #   matplotlib-inline
 typing-extensions==4.12.2
     # via
-    #   -c requirements.txt
+    #   -c /home/danipran/code/smbackend/requirements.txt
     #   pygithub
-urllib3==2.5.0
+urllib3==1.26.20
     # via
-    #   -c requirements.txt
+    #   -c /home/danipran/code/smbackend/requirements.txt
     #   -r requirements-dev.in
     #   pygithub
     #   requests

--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ psycopg2
 sentry-sdk[django]
 tqdm
 tzdata
-urllib3<3
+urllib3<2  # NOTE: As of django-munigeo 0.2.88, urllib3 2.x is not supported.
 whitenoise
 uwsgi
 uwsgitop

--- a/requirements.txt
+++ b/requirements.txt
@@ -150,7 +150,7 @@ uritemplate==4.1.1
     # via drf-spectacular
 url-normalize==1.4.3
     # via requests-cache
-urllib3==2.5.0
+urllib3==1.26.20
     # via
     #   -r requirements.in
     #   bmi-arcgis-restapi


### PR DESCRIPTION
Unfortunately, upgrading urllib3 to a newer version causes issues with django-munigeo. django-munigeo needs to updated before migrating to urllib3 2.x.