### PR TITLE
PL-116: Optimize observation queries

### DIFF
--- a/services/api.py
+++ b/services/api.py
@@ -1267,13 +1267,14 @@ class UnitViewSet(
             )
 
         if "observations" in self.include_fields:
+            now = timezone.now()
             queryset = queryset.prefetch_related(
                 Prefetch(
                     "observation_set",
                     queryset=Observation.objects.filter(
                         Q(property__expiration=None)
-                        | Q(time__gt=timezone.now() - F("property__expiration"))
-                    ),
+                        | Q(time__gt=now - F("property__expiration"))
+                    ).select_related("property"),
                 )
             )
 


### PR DESCRIPTION
## Description

- Use select_related() inside the Prefetch queryset to reduce DB hits for each observation's related property.
- Call timezone.now() once before the queryset, not inside the filter to avoid recalculating
the current time for every row.

## Context

[PL-116](https://helsinkisolutionoffice.atlassian.net/browse/PL-116)


[PL-116]: https://helsinkisolutionoffice.atlassian.net/browse/PL-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ