### PR TITLE
Retain earlier school district data on school district importer error

### DIFF
--- a/services/management/commands/school_district_import/school_district_importer.py
+++ b/services/management/commands/school_district_import/school_district_importer.py
@@ -45,7 +45,7 @@ class SchoolDistrictImporter:
             layer = DataSource(url)[0]
         except Exception as e:
             logger.error(f"Error retrieving data for {source_type}: {e}")
-            return
+            raise
 
         logger.info(f"Retrieved {len(layer)} {source_type} features.")
         logger.info("Processing data...")

--- a/services/management/commands/update_helsinki_preschool_districts.py
+++ b/services/management/commands/update_helsinki_preschool_districts.py
@@ -40,6 +40,7 @@ class Command(BaseCommand):
         "Usage: ./manage.py update_helsinki_preschool_districts"
     )
 
+    @transaction.atomic
     def handle(self, *args, **options):
         importer = SchoolDistrictImporter(district_type="preschool")
 

--- a/services/management/commands/update_helsinki_preschool_districts.py
+++ b/services/management/commands/update_helsinki_preschool_districts.py
@@ -1,9 +1,14 @@
+import logging
+
 from django.core.management.base import BaseCommand
+from django.db import transaction
 from munigeo.models import AdministrativeDivision
 
 from services.management.commands.school_district_import.school_district_importer import (  # noqa: E501
     SchoolDistrictImporter,
 )
+
+logger = logging.getLogger(__name__)
 
 PRESCHOOL_DISTRICT_DATA = [
     {
@@ -36,20 +41,29 @@ class Command(BaseCommand):
     )
 
     def handle(self, *args, **options):
-        division_types = list(
-            {data["division_type"] for data in PRESCHOOL_DISTRICT_DATA}
-        )
-
-        # Remove old divisions before importing new ones to avoid possible duplicates
-        # as the source layers may change
-        AdministrativeDivision.objects.filter(
-            type__type__in=division_types, municipality__id="helsinki"
-        ).delete()
-
         importer = SchoolDistrictImporter(district_type="preschool")
 
+        data_by_division_type = {}
         for data in PRESCHOOL_DISTRICT_DATA:
-            importer.import_districts(data)
+            data_by_division_type.setdefault(data["division_type"], []).append(data)
 
-        for division_type in division_types:
+        for division_type in data_by_division_type.keys():
+            logger.info(f"Updating division type: {division_type}")
+            try:
+                with transaction.atomic():
+                    # Remove old divisions before importing new ones to avoid possible
+                    # duplicates as the source layers may change
+                    AdministrativeDivision.objects.filter(
+                        type__type=division_type, municipality__id="helsinki"
+                    ).delete()
+
+                    for data in data_by_division_type[division_type]:
+                        importer.import_districts(data)
+            except Exception:
+                logger.exception(
+                    "Something went wrong while updating division "
+                    f"type {division_type}, changes rolled back."
+                )
+
+        for division_type in data_by_division_type.keys():
             importer.remove_old_school_year(division_type)

--- a/services/management/commands/update_helsinki_school_districts.py
+++ b/services/management/commands/update_helsinki_school_districts.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.core.management.base import BaseCommand
 from django.db import transaction
 from munigeo.models import AdministrativeDivision
@@ -5,6 +7,8 @@ from munigeo.models import AdministrativeDivision
 from services.management.commands.school_district_import.school_district_importer import (  # noqa: E501
     SchoolDistrictImporter,
 )
+
+logger = logging.getLogger(__name__)
 
 SCHOOL_DISTRICT_DATA = [
     {
@@ -58,18 +62,29 @@ class Command(BaseCommand):
 
     @transaction.atomic
     def handle(self, *args, **options):
-        division_types = list({data["division_type"] for data in SCHOOL_DISTRICT_DATA})
-
-        # Remove old divisions before importing new ones to avoid possible duplicates
-        # as the source layers may change
-        AdministrativeDivision.objects.filter(
-            type__type__in=division_types, municipality__id="helsinki"
-        ).delete()
-
         importer = SchoolDistrictImporter(district_type="school")
 
+        data_by_division_type = {}
         for data in SCHOOL_DISTRICT_DATA:
-            importer.import_districts(data)
+            data_by_division_type.setdefault(data["division_type"], []).append(data)
 
-        for division_type in division_types:
+        for division_type in data_by_division_type.keys():
+            logger.info(f"Updating division type: {division_type}")
+            try:
+                with transaction.atomic():
+                    # Remove old divisions before importing new ones to avoid possible
+                    # duplicates as the source layers may change
+                    AdministrativeDivision.objects.filter(
+                        type__type=division_type, municipality__id="helsinki"
+                    ).delete()
+
+                    for data in data_by_division_type[division_type]:
+                        importer.import_districts(data)
+            except Exception:
+                logger.exception(
+                    "Something went wrong while updating division "
+                    f"type {division_type}, changes rolled back."
+                )
+
+        for division_type in data_by_division_type.keys():
             importer.remove_old_school_year(division_type)


### PR DESCRIPTION
This prevents all of the data from being wiped out if there's, for example, a temporary network outage on the data source at the time of the import.