### PR TITLE
Explicit secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   common:
-    uses: City-of-Helsinki/.github/.github/workflows/ci-django-api.yml@main
+    uses: City-of-Helsinki/.github/.github/workflows/ci-django-api.yml@drop-sed
     secrets: 
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,8 @@ on:
 jobs:
   common:
     uses: City-of-Helsinki/.github/.github/workflows/ci-django-api.yml@main
-    secrets: inherit
+    secrets: 
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     with:
       python-version: "3.12"
       postgres-major-version: 17


### PR DESCRIPTION
Two changes

1) pass SONAR_TOKEN explicitly to the common CI workflow

2) use a branch of the common CI workflow to validate that the flow works and removes warnings from sonarcloud before it is made available to all applications. This will be merged, because we need to see if running the CI against smbackend `main` removes warnings from sonarcloud side. 