### PR TITLE
fix: import Helsinki divisions weekly

### DIFF
--- a/scripts/run_imports.sh
+++ b/scripts/run_imports.sh
@@ -15,6 +15,7 @@ function stage_1 {
     # Import Helsinki, Espoo and HSY administrative divisions,
     # addresses, parking areas, parking payzones and nature reserves.
     # Additionally, index search columns for a better performance.
+    ./manage.py geo_import helsinki --divisions
     ./manage.py geo_import espoo --divisions
     GDAL_HTTP_UNSAFESSL=YES ./manage.py geo_import hsy --divisions
     ./manage.py geo_import helsinki --addresses


### PR DESCRIPTION
## Description

Add missing Helsinki division imports to weekly imports.

## Context

[PL-237](https://helsinkisolutionoffice.atlassian.net/browse/PL-237)

[PL-237]: https://helsinkisolutionoffice.atlassian.net/browse/PL-237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ