### PR TITLE
feat(observations): add UiRas water temperature source

### DIFF
--- a/observations/management/commands/import_swimming_water_temperatures.py
+++ b/observations/management/commands/import_swimming_water_temperatures.py
@@ -13,20 +13,13 @@ Usage:
 """
 
 import logging
-from datetime import UTC
 
 import requests
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
-from django.db import transaction
-from django.utils.dateparse import parse_datetime
-from django.utils.timezone import is_aware, make_aware
 
-from observations.models import (
-    MeasuredObservation,
-    ObservableProperty,
-    UnitLatestObservation,
-)
+from observations.models import ObservableProperty
+from observations.swimming_temperatures import parse_measurement, store_observation
 from services.models import Unit
 
 logger = logging.getLogger(__name__)
@@ -172,7 +165,7 @@ class Command(BaseCommand):
     ):
         """Store an observation, appending to errors on failure."""
         try:
-            return self._store_observation(
+            return store_observation(
                 unit_id, observable_property, temperature, measured_at
             )
         except Exception as exc:  # noqa: BLE001
@@ -180,38 +173,6 @@ class Command(BaseCommand):
             logger.error(msg)
             errors.append(msg)
             return None
-
-    @transaction.atomic
-    def _store_observation(
-        self, unit_id, observable_property, temperature, measured_at
-    ) -> bool:
-        """Store a reading idempotently and update the unit's latest pointer.
-
-        Returns True if a new observation row was created.
-        """
-        observation, created = MeasuredObservation.objects.get_or_create(
-            unit_id=unit_id,
-            property=observable_property,
-            time=measured_at,
-            defaults={"measured_value": temperature},
-        )
-        if not created and observation.measured_value != temperature:
-            observation.measured_value = temperature
-            observation.save(update_fields=["measured_value"])
-
-        latest = (
-            MeasuredObservation.objects.filter(
-                unit_id=unit_id, property=observable_property
-            )
-            .order_by("-time")
-            .first()
-        )
-        UnitLatestObservation.objects.update_or_create(
-            unit_id=unit_id,
-            property=observable_property,
-            defaults={"observation_id": latest.pk},
-        )
-        return created
 
     def _resolve_unit_ids(self, unit_ids_arg: str, base_url: str) -> list[int]:
         """Return unit IDs from --unit-ids, or the live tprId index."""
@@ -266,37 +227,10 @@ class Command(BaseCommand):
         try:
             response = requests.get(url, timeout=15)
             response.raise_for_status()
-            properties = response.json().get("properties", {})
-            return self._parse_measurement(properties.get("measurement"), unit_id)
+            properties = response.json().get("properties") or {}
+            return parse_measurement(properties.get("measurement"), unit_id)
         except requests.RequestException as exc:
             logger.warning(
                 "Could not fetch data for unit %s from %s: %s", unit_id, url, exc
             )
             return None
-
-    def _parse_measurement(self, measurement, unit_id):
-        """Parse a measurement dict into (temperature, measured_at), or None."""
-        if not measurement:
-            logger.debug("No measurement block for unit %s", unit_id)
-            return None
-
-        time_raw = measurement.get("time")
-        measured_at = parse_datetime(str(time_raw)) if time_raw is not None else None
-        try:
-            temp_water = float(measurement.get("temp_water"))
-        except (ValueError, TypeError):
-            temp_water = None
-
-        if temp_water is None or measured_at is None:
-            logger.warning(
-                "Incomplete or invalid measurement for unit %s: temp_water=%r, time=%r",
-                unit_id,
-                measurement.get("temp_water"),
-                time_raw,
-            )
-            return None
-
-        if not is_aware(measured_at):
-            measured_at = make_aware(measured_at, UTC)
-
-        return temp_water, measured_at

--- a/observations/management/commands/import_uiras_swimming_water_temperatures.py
+++ b/observations/management/commands/import_uiras_swimming_water_temperatures.py
@@ -1,0 +1,198 @@
+"""
+Management command: import_uiras_swimming_water_temperatures
+
+Fetches current water temperatures from the UiRas API and stores them as
+MeasuredObservation records linked to the uiras_swimming_water_temperature
+ObservableProperty. Only units configured in settings.UIRAS_OBSERVABLE_UNITS
+(Unit ID -> UiRas feature id) are imported.
+
+Usage:
+    python manage.py import_uiras_swimming_water_temperatures
+    python manage.py import_uiras_swimming_water_temperatures --dry-run
+"""
+
+import logging
+
+import requests
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+from observations.models import ObservableProperty
+from observations.swimming_temperatures import parse_measurement, store_observation
+from services.models import Unit
+
+logger = logging.getLogger(__name__)
+
+PROPERTY_ID = "uiras_swimming_water_temperature"
+
+
+class Command(BaseCommand):
+    help = (
+        "Fetch swimming place water temperatures from the UiRas API and store "
+        "them as measured observations."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Fetch data but do not write anything to the database.",
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        url = settings.UIRAS_BASE_URL
+        unit_feature_map = settings.UIRAS_OBSERVABLE_UNITS or {}
+
+        if not unit_feature_map:
+            raise CommandError(
+                "settings.UIRAS_OBSERVABLE_UNITS is empty; nothing to import."
+            )
+
+        observable_property = self._get_property()
+        known_unit_ids = self._known_unit_ids(unit_feature_map)
+
+        self.stdout.write(
+            self.style.NOTICE(
+                f"Starting UiRas import for {len(known_unit_ids)} unit(s)"
+                + (" [DRY RUN]" if dry_run else "")
+            )
+        )
+
+        features_by_id = self._fetch_features(url)
+        created, units_updated, errors = self._import_units(
+            known_unit_ids,
+            unit_feature_map,
+            features_by_id,
+            observable_property,
+            dry_run,
+        )
+        self._report(created, units_updated, errors)
+
+    def _get_property(self):
+        try:
+            return ObservableProperty.objects.get(pk=PROPERTY_ID)
+        except ObservableProperty.DoesNotExist as exc:
+            raise CommandError(
+                f"ObservableProperty '{PROPERTY_ID}' does not exist. "
+                "Run migrations or load the observation fixtures first."
+            ) from exc
+
+    def _known_unit_ids(self, unit_feature_map):
+        configured_ids = list(unit_feature_map.keys())
+        known_unit_ids = set(
+            Unit.objects.filter(id__in=configured_ids).values_list("id", flat=True)
+        )
+        missing = set(configured_ids) - known_unit_ids
+        if missing:
+            logger.warning(
+                "Skipping %d configured unit(s) not present in the database: %s",
+                len(missing),
+                ", ".join(str(m) for m in sorted(missing)),
+            )
+        return known_unit_ids
+
+    def _fetch_features(self, url):
+        self.stdout.write(f"Fetching UiRas data from {url} …")
+        try:
+            response = requests.get(url, timeout=30)
+            response.raise_for_status()
+        except requests.RequestException as exc:
+            raise CommandError(f"Failed to fetch UiRas data: {exc}") from exc
+
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise CommandError(f"Failed to parse UiRas JSON from {url}: {exc}") from exc
+
+        features = data.get("features") if isinstance(data, dict) else None
+        if not isinstance(features, list):
+            raise CommandError(
+                f"Unexpected UiRas format from {url}: expected a 'features' list. "
+                f"Got: {type(data).__name__}."
+            )
+
+        features_by_id = {}
+        for feature in features:
+            if not isinstance(feature, dict):
+                continue
+            feature_id = feature.get("id") or (feature.get("properties") or {}).get(
+                "id"
+            )
+            if feature_id is not None:
+                features_by_id[str(feature_id)] = feature
+        self.stdout.write(f"  Found {len(features_by_id)} feature(s) in UiRas data.")
+        return features_by_id
+
+    def _import_units(
+        self,
+        known_unit_ids,
+        unit_feature_map,
+        features_by_id,
+        observable_property,
+        dry_run,
+    ):
+        created = 0
+        units_updated = 0
+        errors = []
+        for unit_id in sorted(known_unit_ids):
+            feature = features_by_id.get(str(unit_feature_map[unit_id]))
+            was_created = self._process_unit(
+                unit_id, feature, observable_property, dry_run, errors
+            )
+            if was_created is None:
+                continue
+            if was_created:
+                created += 1
+            units_updated += 1
+        return created, units_updated, errors
+
+    def _process_unit(self, unit_id, feature, observable_property, dry_run, errors):
+        result = self._resolve_measurement(unit_id, feature)
+        if result is None:
+            return None
+        temperature, measured_at = result
+        if dry_run:
+            self.stdout.write(
+                f"  [dry-run] unit={unit_id} temp={temperature}°C at {measured_at}"
+            )
+            return None
+        return self._store_safe(
+            unit_id, observable_property, temperature, measured_at, errors
+        )
+
+    def _resolve_measurement(self, unit_id, feature):
+        if not isinstance(feature, dict):
+            logger.warning("No UiRas feature configured/found for unit %s", unit_id)
+            return None
+        properties = feature.get("properties") or {}
+        measurement = properties.get("measurement")
+        return parse_measurement(measurement, unit_id)
+
+    def _store_safe(
+        self, unit_id, observable_property, temperature, measured_at, errors
+    ):
+        try:
+            return store_observation(
+                unit_id, observable_property, temperature, measured_at
+            )
+        except Exception as exc:  # noqa: BLE001
+            msg = f"Failed to store observation for unit {unit_id}: {exc}"
+            logger.error(msg)
+            errors.append(msg)
+            return None
+
+    def _report(self, created, units_updated, errors):
+        if errors:
+            self.stderr.write(
+                self.style.ERROR(f"Completed with {len(errors)} error(s):")
+            )
+            for err in errors:
+                self.stderr.write(f"  {err}")
+        else:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Done. {created} new reading(s) stored, "
+                    f"{units_updated} unit(s) updated."
+                )
+            )

--- a/observations/migrations/0012_uiras_swimming_water_temperature_property.py
+++ b/observations/migrations/0012_uiras_swimming_water_temperature_property.py
@@ -1,0 +1,41 @@
+from django.db import migrations
+
+PROPERTY_ID = "uiras_swimming_water_temperature"
+SERVICE_IDS = [730, 731]
+
+
+def create_property(apps, schema_editor):
+    observable_property_model = apps.get_model("observations", "ObservableProperty")
+    service_model = apps.get_model("services", "Service")
+
+    prop, _ = observable_property_model.objects.update_or_create(
+        id=PROPERTY_ID,
+        defaults={
+            "name": "Water temperature (UiRas)",
+            "name_fi": "Veden lämpötila (UiRas)",
+            "name_sv": "Vattentemperatur (UiRas)",
+            "name_en": "Water temperature (UiRas)",
+            "measurement_unit": "°C",
+            "observation_type": "observations.MeasuredObservation",
+        },
+    )
+
+    existing_services = service_model.objects.filter(id__in=SERVICE_IDS)
+    if existing_services.exists():
+        prop.services.add(*existing_services)
+
+
+def remove_property(apps, schema_editor):
+    observable_property_model = apps.get_model("observations", "ObservableProperty")
+    observable_property_model.objects.filter(id=PROPERTY_ID).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("observations", "0011_measured_swimming_water_temperature_property"),
+        ("services", "0121_make_requeststatistic_timeframe_unique"),
+    ]
+
+    operations = [
+        migrations.RunPython(create_property, remove_property),
+    ]

--- a/observations/swimming_temperatures.py
+++ b/observations/swimming_temperatures.py
@@ -1,0 +1,78 @@
+"""Shared helpers for importing swimming water temperatures from the
+sensoripaja.fi and UiRas import management commands.
+"""
+
+import logging
+import math
+from datetime import UTC
+
+from django.db import transaction
+from django.utils.dateparse import parse_datetime
+from django.utils.timezone import is_aware, make_aware
+
+from observations.models import MeasuredObservation, UnitLatestObservation
+
+logger = logging.getLogger(__name__)
+
+
+def parse_measurement(measurement, unit_id):
+    """Parse a measurement dict into (temperature, measured_at), or None."""
+    if not measurement:
+        logger.debug("No measurement block for unit %s", unit_id)
+        return None
+
+    raw_temp = measurement.get("temp_water")
+    time_raw = measurement.get("time")
+    measured_at = parse_datetime(str(time_raw)) if time_raw is not None else None
+    try:
+        temp_water = float(raw_temp) if raw_temp is not None else None
+    except (ValueError, TypeError):
+        temp_water = None
+
+    if temp_water is not None and not math.isfinite(temp_water):
+        temp_water = None
+
+    if temp_water is None or measured_at is None:
+        logger.warning(
+            "Incomplete measurement for unit %s: temp_water=%r, time=%r",
+            unit_id,
+            raw_temp,
+            time_raw,
+        )
+        return None
+
+    if not is_aware(measured_at):
+        measured_at = make_aware(measured_at, UTC)
+
+    return temp_water, measured_at
+
+
+@transaction.atomic
+def store_observation(unit_id, observable_property, temperature, measured_at) -> bool:
+    """Store a reading idempotently and update the unit's latest pointer.
+
+    Returns True if a new observation row was created.
+    """
+    observation, created = MeasuredObservation.objects.get_or_create(
+        unit_id=unit_id,
+        property=observable_property,
+        time=measured_at,
+        defaults={"measured_value": temperature},
+    )
+    if not created and observation.measured_value != temperature:
+        observation.measured_value = temperature
+        observation.save(update_fields=["measured_value"])
+
+    latest = (
+        MeasuredObservation.objects.filter(
+            unit_id=unit_id, property=observable_property
+        )
+        .order_by("-time")
+        .first()
+    )
+    UnitLatestObservation.objects.update_or_create(
+        unit_id=unit_id,
+        property=observable_property,
+        defaults={"observation_id": latest.pk},
+    )
+    return created

--- a/observations/tests/fixtures.py
+++ b/observations/tests/fixtures.py
@@ -245,3 +245,17 @@ def unit_latest_measured_observation(unit, measured_property, measured_observati
         property=measured_property,
         unit=unit,
     )
+
+
+@pytest.fixture
+def uiras_property(service):
+    p, _ = ObservableProperty.objects.update_or_create(
+        id="uiras_swimming_water_temperature",
+        defaults={
+            "name": "Water temperature (UiRas)",
+            "measurement_unit": "°C",
+            "observation_type": "observations.MeasuredObservation",
+        },
+    )
+    p.services.add(service)
+    return p

--- a/observations/tests/test_import_uiras_swimming_water_temperatures.py
+++ b/observations/tests/test_import_uiras_swimming_water_temperatures.py
@@ -1,0 +1,157 @@
+from unittest import mock
+
+import pytest
+from django.core.management import call_command
+from django.test import override_settings
+from fixtures import *  # noqa: F401,F403
+
+from observations.models import MeasuredObservation, UnitLatestObservation
+
+COMMAND = "import_uiras_swimming_water_temperatures"
+MODULE = "observations.management.commands.import_uiras_swimming_water_temperatures"
+
+FEATURE_ID = "70B3D57050001ADA"
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+def make_requests_get(payload):
+    def _get(url, *args, **kwargs):
+        return FakeResponse(payload)
+
+    return _get
+
+
+def feature(feature_id, temp, time):
+    return {
+        "id": feature_id,
+        "type": "Feature",
+        "properties": {"measurement": {"temp_water": temp, "time": time}},
+    }
+
+
+def feature_collection(features):
+    return {"type": "FeatureCollection", "features": features}
+
+
+@pytest.mark.django_db
+@override_settings(UIRAS_OBSERVABLE_UNITS={1: FEATURE_ID})
+def test__command_imports_measured_observation(unit, uiras_property):
+    payload = feature_collection(
+        [feature(FEATURE_ID, 13.25, "2026-06-05T12:08:34+03:00")]
+    )
+
+    with mock.patch(f"{MODULE}.requests.get", make_requests_get(payload)):
+        call_command(COMMAND)
+
+    assert MeasuredObservation.objects.filter(unit=unit).count() == 1
+    obs = MeasuredObservation.objects.get(unit=unit)
+    assert obs.measured_value == pytest.approx(13.25)
+    latest = UnitLatestObservation.objects.get(unit=unit, property=uiras_property)
+    assert latest.observation_id == obs.pk
+
+
+@pytest.mark.django_db
+@override_settings(UIRAS_OBSERVABLE_UNITS={1: FEATURE_ID})
+def test__command_is_idempotent_and_tracks_latest(unit, uiras_property):
+    first = feature_collection(
+        [feature(FEATURE_ID, 13.25, "2026-06-05T12:08:34+03:00")]
+    )
+    with mock.patch(f"{MODULE}.requests.get", make_requests_get(first)):
+        call_command(COMMAND)
+        call_command(COMMAND)
+
+    assert MeasuredObservation.objects.filter(unit=unit).count() == 1
+
+    second = feature_collection(
+        [feature(FEATURE_ID, 14.10, "2026-06-05T12:28:34+03:00")]
+    )
+    with mock.patch(f"{MODULE}.requests.get", make_requests_get(second)):
+        call_command(COMMAND)
+
+    assert MeasuredObservation.objects.filter(unit=unit).count() == 2
+    latest = UnitLatestObservation.objects.get(unit=unit, property=uiras_property)
+    latest_obs = MeasuredObservation.objects.get(pk=latest.observation_id)
+    assert latest_obs.measured_value == pytest.approx(14.10)
+
+
+@pytest.mark.django_db
+@override_settings(UIRAS_OBSERVABLE_UNITS={1: FEATURE_ID})
+def test__command_dry_run_writes_nothing(unit, uiras_property):
+    payload = feature_collection(
+        [feature(FEATURE_ID, 13.25, "2026-06-05T12:08:34+03:00")]
+    )
+
+    with mock.patch(f"{MODULE}.requests.get", make_requests_get(payload)):
+        call_command(COMMAND, "--dry-run")
+
+    assert MeasuredObservation.objects.count() == 0
+    assert UnitLatestObservation.objects.count() == 0
+
+
+@pytest.mark.django_db
+@override_settings(UIRAS_OBSERVABLE_UNITS={1: FEATURE_ID, 99999999: "DEADBEEF"})
+def test__command_skips_units_not_in_db(unit, uiras_property):
+    payload = feature_collection(
+        [
+            feature(FEATURE_ID, 13.25, "2026-06-05T12:08:34+03:00"),
+            feature("DEADBEEF", 9.9, "2026-06-05T12:08:34+03:00"),
+        ]
+    )
+
+    with mock.patch(f"{MODULE}.requests.get", make_requests_get(payload)):
+        call_command(COMMAND)
+
+    assert MeasuredObservation.objects.filter(unit=unit).count() == 1
+    assert MeasuredObservation.objects.count() == 1
+
+
+@pytest.mark.django_db
+@override_settings(UIRAS_OBSERVABLE_UNITS={1: FEATURE_ID})
+def test__command_handles_missing_feature(unit, uiras_property):
+    payload = feature_collection(
+        [feature("SOMETHING_ELSE", 13.25, "2026-06-05T12:08:34+03:00")]
+    )
+
+    with mock.patch(f"{MODULE}.requests.get", make_requests_get(payload)):
+        call_command(COMMAND)
+
+    assert MeasuredObservation.objects.count() == 0
+
+
+@pytest.mark.django_db
+@override_settings(UIRAS_OBSERVABLE_UNITS={1: FEATURE_ID})
+def test__command_handles_null_properties(unit, uiras_property):
+    payload = feature_collection([{"id": FEATURE_ID, "properties": None}])
+
+    with mock.patch(f"{MODULE}.requests.get", make_requests_get(payload)):
+        call_command(COMMAND)
+
+    assert MeasuredObservation.objects.count() == 0
+
+
+@pytest.mark.django_db
+@override_settings(UIRAS_OBSERVABLE_UNITS={1: FEATURE_ID})
+def test__command_handles_missing_temp_water(unit, uiras_property):
+    payload = feature_collection(
+        [
+            {
+                "id": FEATURE_ID,
+                "properties": {"measurement": {"time": "2026-06-05T12:08:34+03:00"}},
+            }
+        ]
+    )
+
+    with mock.patch(f"{MODULE}.requests.get", make_requests_get(payload)):
+        call_command(COMMAND)
+
+    assert MeasuredObservation.objects.count() == 0

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -35,6 +35,7 @@ timeout 20m nice python manage.py lipas_import_3d \
     --muni-id=149 2>&1
 timeout 20m nice python manage.py update_mobility_service_nodes 2>&1
 timeout 20m nice python manage.py import_swimming_water_temperatures 2>&1 || true
+timeout 20m nice python manage.py import_uiras_swimming_water_temperatures 2>&1 || true
 
 if [[ -n "${IMPORT_HEALTHCHECK_URL}" ]]; then
   curl --retry 3 "${IMPORT_HEALTHCHECK_URL}"

--- a/smbackend/settings.py
+++ b/smbackend/settings.py
@@ -72,6 +72,10 @@ env = Env(
         str,
         "https://api.sensoripaja.fi/swimhelsinki/tpr",
     ),
+    UIRAS_BASE_URL=(
+        str,
+        "https://bri3.fvh.io/opendata/uiras/uiras_latest.geojson",
+    ),
 )
 
 env_path = BASE_DIR / ".env"
@@ -96,6 +100,15 @@ EMAIL_HOST_PASSWORD = env("EMAIL_HOST_PASSWORD")
 PICTURE_URL_REWRITE_ENABLED = env("PICTURE_URL_REWRITE_ENABLED")
 IMPORT_DATA_PATH = env("IMPORT_DATA_PATH")
 SWIMMING_TEMPERATURES_BASE_URL = env("SWIMMING_TEMPERATURES_BASE_URL")
+UIRAS_BASE_URL = env("UIRAS_BASE_URL")
+
+# Units exposing UiRas water temperature, mapping Unit ID -> UiRas feature id.
+# Only these units are imported by import_uiras_swimming_water_temperatures.
+UIRAS_OBSERVABLE_UNITS = {
+    42611: "70B3D57050001ADA",
+    42505: "70B3D57050001BA6",
+    39368: "70B3D5705000516A",
+}
 
 # Application definition
 INSTALLED_APPS = [


### PR DESCRIPTION
- Add uiras_swimming_water_temperature ObservableProperty (migration 0012)
- Add import_uiras_swimming_water_temperatures management command: fetches FeatureCollection from UiRas API, maps features to units via settings.UIRAS_OBSERVABLE_UNITS, stores MeasuredObservation records idempotently, updates UnitLatestObservation
- Extract shared parse_measurement/store_observation helpers to observations/swimming_temperatures.py; refactor sensoripaja command to use shared helpers
- Add UIRAS_BASE_URL and UIRAS_OBSERVABLE_UNITS settings
- Add tests: import, idempotency, dry-run, missing units/feature, missing temp_water; add uiras_property fixture
- Add import_uiras_swimming_water_temperatures to update.sh

Refs: HUL-78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import UiRas swimming-water temperature readings with optional dry-run.
  * Added observable property for UiRas swimming-water temperature.

* **Refactor**
  * Extracted measurement parsing and idempotent storage into reusable helpers.

* **Migrations**
  * Migration to create the UiRas swimming-water temperature property and service associations.

* **Chores**
  * System update now triggers UiRas import; added UiRas base URL and unit mapping.

* **Tests**
  * Tests for import behavior, idempotency, dry-run, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->