### PR TITLE
uv updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,17 +12,15 @@ repos:
       - id: check-toml
       - id: check-added-large-files
   - repo: https://github.com/adamchainz/django-upgrade
-    rev: "1.30.0"  # replace with latest tag on GitHub
+    rev: "1.30.0"
     hooks:
       - id: django-upgrade
         args: [--target-version, "5.2"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.16
+    rev: v0.15.19
     hooks:
-      # Run the linter.
       - id: ruff-check
         args: [ "--fix" ]
-      # Run the formatter.
       - id: ruff-format
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: v9.25.0
@@ -35,6 +33,6 @@ repos:
     hooks:
       - id: shellcheck
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.19
+    rev: 0.11.24
     hooks:
       - id: uv-lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN dnf update -y && dnf install -y \
     nmap-ncat \
     gettext \
     postgresql \
-    && uv sync --frozen --no-dev --inexact --group prod \
+    && uv sync --frozen --no-dev --group prod \
     && uwsgi --build-plugin https://github.com/City-of-Helsinki/uwsgi-sentry \
     && dnf clean all
 
@@ -53,7 +53,7 @@ FROM appbase AS development
 # ==============================
 
 ENV DEV_SERVER=True
-RUN uv sync --frozen --inexact
+RUN uv sync --frozen --group prod
 COPY . .
 USER default
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV DJANGO_URL_PREFIX=/
 WORKDIR /app
 USER root
 
-COPY --from=ghcr.io/astral-sh/uv:0.11.19 /uv /uvx /usr/local/bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.24@sha256:99ea34acedc870ba4ad11a1f540a1c04267c9f30aadc465a94406f52dfda2c36 /uv /uvx /usr/local/bin/
 
 ENV UV_PROJECT_ENVIRONMENT=/opt/app-root \
     UV_COMPILE_BYTECODE=1 \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ package = false
 # Supply-chain protection: only consider package versions published at least
 # three days ago, giving time for malicious or broken releases to be detected
 # and yanked.
-exclude-newer = "3 days"
+exclude-newer = "P3D"
 
 [tool.ruff]
 target-version = "py312"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
     "djangorestframework-jsonp",
     "drf-spectacular",
     "geopy",
-    "ipython",
     "libvoikko",
     "lxml",
     "psycopg[c]",
@@ -47,6 +46,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "ipython",
     "jedi",
     "parso",
     "pytest-django",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,14 @@
     ".": {
       "release-type": "python",
       "package-name": "smbackend",
-      "extra-files": ["pyproject.toml"],
+      "extra-files": [
+        {"path": "pyproject.toml", "type": "toml"},
+        {
+          "path": "uv.lock",
+          "type": "toml",
+          "jsonpath": "$.package[?(@.name=='smbackend')].version"
+        }
+      ],
       "changelog-sections": [
         {"type": "feat", "section": "Features"},
         {"type": "fix", "section": "Bug Fixes"},

--- a/uv.lock
+++ b/uv.lock
@@ -1090,7 +1090,6 @@ dependencies = [
     { name = "djangorestframework-jsonp" },
     { name = "drf-spectacular" },
     { name = "geopy" },
-    { name = "ipython" },
     { name = "libvoikko" },
     { name = "lxml" },
     { name = "psycopg", extra = ["c"] },
@@ -1108,6 +1107,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "ipython" },
     { name = "jedi" },
     { name = "parso" },
     { name = "pytest-cov" },
@@ -1139,7 +1139,6 @@ requires-dist = [
     { name = "djangorestframework-jsonp" },
     { name = "drf-spectacular" },
     { name = "geopy" },
-    { name = "ipython" },
     { name = "libvoikko" },
     { name = "lxml" },
     { name = "psycopg", extras = ["c"] },
@@ -1157,6 +1156,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "ipython" },
     { name = "jedi" },
     { name = "parso" },
     { name = "pytest-cov" },


### PR DESCRIPTION
- build(docker): update uv to v.0.11.24
- build(docker): update uv sync to be exact
- move ipython to dev-dependencies
- use shorter "exclude-newer"-format
- update pre-commit tool versions
- release-please: sync uv.lock lockfile version with pyproject.toml

Refs: [PL-287](https://helsinkisolutionoffice.atlassian.net/browse/PL-287)

[PL-287]: https://helsinkisolutionoffice.atlassian.net/browse/PL-287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and tooling versions for a smoother development and release workflow.
  * Tightened dependency syncing behavior in container builds for more consistent environments.
  * Moved one interactive Python dependency into the development-only set.
  * Improved release version tracking so package updates are detected more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->