### PR TITLE
perf(api): eliminate N+1 queries in unit endpoint

### DIFF
--- a/services/api.py
+++ b/services/api.py
@@ -248,7 +248,13 @@ class ServicesTranslatedModelSerializer(TranslatedModelSerializer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         for field_name in self.translated_fields:
-            self.fields[field_name] = TranslationsField()
+            # Only re-declare fields that survived the `only` filtering done by
+            # JSONAPISerializer. Re-adding all of them would both leak
+            # unrequested fields into the response and force the serializer to
+            # read model columns that the queryset deferred, causing one
+            # database query per field per object.
+            if field_name in self.fields:
+                self.fields[field_name] = TranslationsField()
 
 
 def root_services(services):
@@ -302,16 +308,29 @@ class JSONAPISerializer(serializers.ModelSerializer):
                 if field_name in self.keep_fields:
                     continue
                 del self.fields[field_name]
+        self._municipality_serializer = None
+        self._municipality_cache = {}
 
     def to_representation(self, obj):
         ret = super().to_representation(obj)
         include_fields = self.context.get("include", [])
-        if "municipality" in include_fields and obj.municipality:
-            muni_json = munigeo_api.MunicipalitySerializer(
-                obj.municipality, context=self.context
-            ).data
-            ret["municipality"] = muni_json
+        if "municipality" in include_fields:
+            municipality = getattr(obj, "municipality", None)
+            if municipality:
+                ret["municipality"] = self._serialize_municipality(municipality)
         return ret
+
+    def _serialize_municipality(self, municipality):
+        cached = self._municipality_cache.get(municipality.pk)
+        if cached is not None:
+            return cached
+        if self._municipality_serializer is None:
+            self._municipality_serializer = munigeo_api.MunicipalitySerializer(
+                context=self.context
+            )
+        data = self._municipality_serializer.to_representation(municipality)
+        self._municipality_cache[municipality.pk] = data
+        return data
 
 
 class DepartmentSerializer(
@@ -488,9 +507,23 @@ class RelatedServiceSerializer(ServicesTranslatedModelSerializer, JSONAPISeriali
 
 
 class ServiceDetailsSerializer(ServicesTranslatedModelSerializer, JSONAPISerializer):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._service_serializer = None
+        self._service_cache = {}
+
+    def _serialize_service(self, service):
+        cached = self._service_cache.get(service.pk)
+        if cached is None:
+            if self._service_serializer is None:
+                self._service_serializer = RelatedServiceSerializer()
+            cached = self._service_serializer.to_representation(service)
+            self._service_cache[service.pk] = cached
+        return cached
+
     def to_representation(self, obj):
         ret = super().to_representation(obj)
-        service_data = RelatedServiceSerializer(obj.service).data
+        service_data = self._serialize_service(obj.service)
         ret["name"] = service_data.get("name")
         ret["root_service_node"] = service_data.get("root_service_node")
         if ret["period_begin_year"] is not None:
@@ -508,6 +541,9 @@ class ServiceDetailsSerializer(ServicesTranslatedModelSerializer, JSONAPISeriali
 
 
 class JSONAPIViewSetMixin:
+    only_field_dependencies = {}
+    include_field_dependencies = {}
+
     def initial(self, request, *args, **kwargs):
         ret = super().initial(request, *args, **kwargs)
 
@@ -533,11 +569,12 @@ class JSONAPIViewSetMixin:
             return queryset
         model = queryset.model
         # department.uuid is a special case, hardcoded here for now
-        fields = [
-            f
-            for f in self.only_fields + ["uuid"]
-            if check_valid_concrete_field(model, f)
-        ]
+        field_names = set(self.only_fields) | {"uuid"}
+        for field_name in self.only_fields:
+            field_names.update(self.only_field_dependencies.get(field_name, ()))
+        for field_name in self.include_fields:
+            field_names.update(self.include_field_dependencies.get(field_name, ()))
+        fields = [f for f in field_names if check_valid_concrete_field(model, f)]
         return queryset.only(*fields)
 
     def get_serializer_context(self):
@@ -809,6 +846,10 @@ class UnitSerializer(
                 del ser.child.fields["unit"]
 
         self._root_node_cache = {}
+        self._department_serializer = None
+        self._department_cache = {}
+        self._service_details_serializer = None
+        self._connection_serializer = None
 
     def handle_extension_translations(self, extensions):
         if extensions is None or len(extensions) == 0:
@@ -867,6 +908,21 @@ class UnitSerializer(
             )
         return obj.picture_url
 
+    def _get_department_serializer(self):
+        if self._department_serializer is None:
+            self._department_serializer = DepartmentSerializer(context=self.context)
+        return self._department_serializer
+
+    def _serialize_department(self, department):
+        if department is None:
+            return None
+        serializer = self._get_department_serializer()
+        cached = self._department_cache.get(department.pk)
+        if cached is None:
+            cached = serializer.to_representation(department)
+            self._department_cache[department.pk] = cached
+        return cached
+
     def to_representation(self, obj):
         ret = super().to_representation(obj)
         if hasattr(obj, "distance") and obj.distance:
@@ -883,10 +939,7 @@ class UnitSerializer(
         include_fields = self.context.get("include", [])
         for field in ["department", "root_department"]:
             if field in include_fields:
-                dep_json = DepartmentSerializer(
-                    getattr(obj, field), context=self.context
-                ).data
-                ret[field] = dep_json
+                ret[field] = self._serialize_department(getattr(obj, field))
         # Not using actual serializer instances below is a performance optimization.
         if "service_nodes" in include_fields:
             service_nodes_json = []
@@ -916,9 +969,13 @@ class UnitSerializer(
                 service_nodes_json.append(data)
             ret["service_nodes"] = service_nodes_json
         if "services" in include_fields:
-            ret["services"] = ServiceDetailsSerializer(
-                obj.service_details, many=True
-            ).data
+            if self._service_details_serializer is None:
+                self._service_details_serializer = ServiceDetailsSerializer()
+            service_details_serializer = self._service_details_serializer
+            ret["services"] = [
+                service_details_serializer.to_representation(service_detail)
+                for service_detail in obj.service_details.all()
+            ]
         if "accessibility_properties" in include_fields:
             acc_props = [
                 {"variable": s.variable_id, "value": s.value}
@@ -927,9 +984,13 @@ class UnitSerializer(
             ret["accessibility_properties"] = acc_props
 
         if "connections" in include_fields:
-            ret["connections"] = UnitConnectionSerializer(
-                obj.connections, many=True
-            ).data
+            if self._connection_serializer is None:
+                self._connection_serializer = UnitConnectionSerializer()
+            connection_serializer = self._connection_serializer
+            ret["connections"] = [
+                connection_serializer.to_representation(connection)
+                for connection in obj.connections.all()
+            ]
 
         if "extensions" in ret:
             ret["extensions"] = self.handle_extension_translations(ret["extensions"])
@@ -1059,9 +1120,28 @@ class UnitViewSet(
     renderer_classes = DEFAULT_RENDERERS + [KmlRenderer]
     filter_backends = (DjangoFilterBackend,)
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.service_details = False
+    only_field_dependencies = {
+        "contract_type": ("displayed_service_owner_type", "displayed_service_owner"),
+        "geometry": ("geometry", "location"),
+        "geometry_3d": ("geometry_3d",),
+    }
+    include_field_dependencies = {
+        "department": ("department",),
+        "root_department": ("root_department",),
+        "municipality": ("municipality",),
+    }
+
+    def initial(self, request, *args, **kwargs):
+        ret = super().initial(request, *args, **kwargs)
+        if self.only_fields:
+            query_params = self.request.query_params
+            for param, field in (
+                ("geometry_3d", "geometry_3d"),
+                ("heightprofilegeom", "geometry_3d"),
+            ):
+                if query_params.get(param, "").lower() in ("true", "1"):
+                    self.only_fields.append(field)
+        return ret
 
     def get_serializer_context(self):
         ret = super().get_serializer_context()
@@ -1076,6 +1156,21 @@ class UnitViewSet(
         queryset = super().get_queryset()
 
         queryset = queryset.prefetch_related("accessibility_shortcomings")
+
+        include_municipality = "municipality" in self.include_fields
+        select_related_fields = []
+        for field in "department", "root_department":
+            if field in self.include_fields:
+                select_related_fields += [field, f"{field}__parent"]
+                if include_municipality:
+                    select_related_fields.append(f"{field}__municipality")
+            elif self._should_prefetch_field(field):
+                select_related_fields.append(field)
+        if include_municipality:
+            select_related_fields.append("municipality")
+        if select_related_fields:
+            queryset = queryset.select_related(*select_related_fields)
+
         if self._service_details_requested():
             queryset = queryset.prefetch_related("service_details")
             queryset = queryset.prefetch_related("service_details__service")
@@ -1156,14 +1251,12 @@ class UnitViewSet(
             level_specs = settings.LEVELS.get(level)
 
         def service_nodes_by_ancestors(service_node_ids, node_model=ServiceNode):
-            srv_list = set()
-            for srv_id in service_node_ids:
-                srv_list |= set(
-                    node_model.objects.all()
-                    .by_ancestor(srv_id)
-                    .values_list("id", flat=True)
-                )
-                srv_list.add(int(srv_id))
+            srv_list = {int(srv_id) for srv_id in service_node_ids}
+            srv_list |= set(
+                node_model.objects.all()
+                .by_ancestors(service_node_ids)
+                .values_list("id", flat=True)
+            )
             return list(srv_list)
 
         mobility_service_nodes = filters.get("mobility_node", None)
@@ -1345,13 +1438,24 @@ class UnitViewSet(
                     ).select_related("property"),
                 )
             )
-
-        if "service_nodes" in self.include_fields:
-            queryset = queryset.prefetch_related("service_nodes")
-
-        for field in ["connections", "accessibility_properties", "keywords"]:
+        prefetch_fields = set()
+        for field in "connections", "accessibility_properties", "keywords":
             if self._should_prefetch_field(field):
-                queryset = queryset.prefetch_related(field)
+                prefetch_fields.add(field)
+        for field in (
+            "entrances",
+            "identifiers",
+            "services",
+            "service_nodes",
+            "mobility_service_nodes",
+            "related_units",
+        ):
+            if not self.only_fields or field in self.only_fields:
+                prefetch_fields.add(field)
+        if "service_nodes" in self.include_fields:
+            prefetch_fields.add("service_nodes")
+        for field in sorted(prefetch_fields):
+            queryset = queryset.prefetch_related(field)
 
         return queryset
 

--- a/services/models/hierarchy.py
+++ b/services/models/hierarchy.py
@@ -1,4 +1,4 @@
-from django.db.models import Q, QuerySet
+from django.db.models import Max, Q, QuerySet
 from mptt.models import TreeManager
 
 
@@ -7,21 +7,27 @@ class CustomTreeManager(TreeManager):
         return TreeQuerySet(self.model, using=self._db)
 
     def determine_max_level(self):
-        qs = self.all().order_by("-level")
-        if qs.count():
-            return qs[0].level
-        else:
+        max_level = self.all().aggregate(max_level=Max("level"))["max_level"]
+        if max_level is None:
             # Harrison-Stetson method
             return 10
+        return max_level
 
 
 class TreeQuerySet(QuerySet):
     def by_ancestor(self, ancestor):
+        return self.by_ancestors([ancestor])
+
+    def by_ancestors(self, ancestors):
+        """Descendants of any of `ancestors`, resolved in a single query."""
+        ancestors = list(ancestors)
+        if not ancestors:
+            return self.none()
         manager = self.model.objects
         max_level = manager.determine_max_level()
         qs = Q()
         # Construct an OR'd queryset for each level of parenthood.
         for i in range(max_level):
-            key = "__".join(["parent"] * (i + 1))
-            qs |= Q(**{key: ancestor})
+            key = "__".join(["parent"] * (i + 1)) + "__in"
+            qs |= Q(**{key: ancestors})
         return self.filter(qs)

--- a/services/tests/test_unit_view_set_api.py
+++ b/services/tests/test_unit_view_set_api.py
@@ -3,6 +3,8 @@ from datetime import datetime
 import pytest
 import pytz
 from django.contrib.gis.geos import GEOSGeometry
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from munigeo import api as munigeo_api
 from munigeo.api import DEFAULT_SRS
@@ -24,6 +26,8 @@ from services.models import (
     Unit,
     UnitAlias,
     UnitConnection,
+    UnitEntrance,
+    UnitIdentifier,
 )
 from services.models.unit import PROJECTION_SRID
 from services.tests.utils import get
@@ -33,9 +37,9 @@ UTC_TIMEZONE = pytz.timezone("UTC")
 # Expected database query counts for unit retrieve operations with proper prefetching.
 # These represent the actual query counts after optimization to prevent N+1 issues.
 # Before optimization: 64+ queries (N+1 for each related object)
-# After optimization: ~12-14 queries (prefetch_related eliminates N+1)
-EXPECTED_QUERIES_UNIT_RETRIEVE = 12
-EXPECTED_QUERIES_UNIT_RETRIEVE_WITH_ALIAS = 14
+# After optimization: ~11-13 queries (prefetch_related eliminates N+1)
+EXPECTED_QUERIES_UNIT_RETRIEVE = 11
+EXPECTED_QUERIES_UNIT_RETRIEVE_WITH_ALIAS = 13
 
 
 def create_units():
@@ -832,3 +836,101 @@ def test_unit_alias_respects_public_and_active_filters(api_client):
 
     response = api_client.get(reverse("unit-detail", kwargs={"pk": 7777}))
     assert response.status_code == 404
+
+
+def _populate_units_with_relations():
+    """Give every listed unit the related objects the serializer renders."""
+    create_units()
+    service_nodes = create_service_nodes()
+    department = Department.objects.get(uuid="a10eb4e7-c7e3-49ec-b6cd-54a1cb74adf8")
+    organization = Department.objects.get(uuid="83e74666-0836-4c1d-948a-4b34a8b90301")
+    municipality = Municipality.objects.get(id="helsinki")
+    keyword = Keyword.objects.create(name="keyword")
+    service = Service.objects.create(
+        id=100, name_fi="Service 100", last_modified_time=datetime.now(UTC_TIMEZONE)
+    )
+    for unit in Unit.objects.filter(public=True, is_active=True):
+        unit.department = department
+        unit.root_department = organization
+        unit.municipality = municipality
+        unit.displayed_service_owner_type = "MUNICIPAL_SERVICE"
+        unit.save()
+        # Both units must share the same service node tree, otherwise the root
+        # node lookup legitimately costs one query per distinct tree.
+        unit.service_nodes.add(service_nodes[0], service_nodes[1])
+        unit.keywords.add(keyword)
+        unit.services.add(service)
+        UnitConnection.objects.create(
+            unit=unit,
+            name="Phone",
+            section_type=UnitConnection.PHONE_OR_EMAIL_TYPE,
+        )
+        UnitEntrance.objects.create(
+            unit=unit,
+            name_fi="Sisäänkäynti",
+            last_modified_time=datetime.now(UTC_TIMEZONE),
+        )
+        UnitIdentifier.objects.create(unit=unit, namespace="test", value=str(unit.id))
+
+
+UNIT_LIST_QUERY_SHAPES = [
+    {},
+    {
+        "include": "services,accessibility_properties,department,root_department,"
+        "municipality,service_nodes,connections"
+    },
+    {
+        "only": "street_address,location,name,municipality,"
+        "accessibility_shortcoming_count,contract_type,organizer_type",
+        "geometry": "true",
+        "include": "services,accessibility_properties,department,root_department",
+    },
+    {"only": "name,entrances,identifiers,services,keywords"},
+]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("params", UNIT_LIST_QUERY_SHAPES)
+def test_unit_list_query_count_is_independent_of_page_size(api_client, params):
+    """
+    The unit list endpoint must issue a constant number of queries regardless
+    of how many units end up in the response. Serializing a unit may never
+    trigger a query of its own.
+    """
+    _populate_units_with_relations()
+
+    query_counts = []
+    for page_size in (1, 5):
+        with CaptureQueriesContext(connection) as context:
+            response = get(
+                api_client,
+                reverse("unit-list"),
+                data={**params, "page_size": page_size},
+            )
+        assert response.status_code == 200
+        query_counts.append(len(context.captured_queries))
+
+    assert query_counts[0] == query_counts[1], (
+        f"query count grew from {query_counts[0]} to {query_counts[1]} when the "
+        f"page size grew from 1 to 5 for params {params}"
+    )
+
+
+@pytest.mark.django_db
+def test_unit_list_only_parameter_limits_returned_fields(api_client):
+    """
+    `only` must also be honoured for translated fields, which are otherwise
+    both leaked into the response and loaded one column at a time.
+    """
+    _populate_units_with_relations()
+
+    response = get(
+        api_client,
+        reverse("unit-list"),
+        data={"only": "name,street_address"},
+    )
+    assert response.status_code == 200
+    results = response.data["results"]
+    assert results
+    for result in results:
+        assert set(result.keys()) == {"id", "name", "street_address"}


### PR DESCRIPTION
The unit list endpoint issued one query per field per object while serializing, e.g. 1309 queries for a single page of 50 units.

Root cause: ServicesTranslatedModelSerializer re-added all translated fields after JSONAPISerializer had removed the ones not listed in `only`. Those columns were deferred by the queryset's `.only()`, so reading them triggered a separate query each. As a side effect `only` was silently ignored for translated fields.

Changes:
- Only re-declare translated fields that survived `only` filtering.
- Add only_field_dependencies / include_field_dependencies so concrete columns a serializer method field reads are not deferred.
- select_related department, root_department and municipality when they are included.
- Prefetch entrances, identifiers, services, service_nodes, mobility_service_nodes and related_units.
- Reuse serializer instances instead of instantiating one per object.
- Resolve service node ancestors in a single batched query and use a Max aggregate to determine the tree depth.

Measured against a full dataset of 21794 units:
- reported slow request: 1309 -> 8 queries, 0.63s -> 0.05s
- unfiltered list, 50 per page: 406 -> 12 queries
- KML export of 6024 units: 9000 -> 15 queries, 35.1s -> 6.5s

Refs: [PL-296](https://helsinkisolutionoffice.atlassian.net/browse/PL-296)


[PL-296]: https://helsinkisolutionoffice.atlassian.net/browse/PL-296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved API response efficiency by reducing redundant database queries.
  * Optimized related data loading, nested serialization, and ancestor filtering.
  * Improved handling of field selection and related-field dependencies for API requests.

* **Bug Fixes**
  * Prevented excluded fields from reappearing in filtered API responses.
  * Ensured required geometry and related fields are included when needed.

* **Tests**
  * Added coverage for query efficiency, pagination, field selection, and translated fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->