### PR TITLE
fix(search): treat '|' surrounded by spaces as literal, not OR

### DIFF
--- a/services/search/api.py
+++ b/services/search/api.py
@@ -238,10 +238,31 @@ class SearchSerializer(serializers.Serializer):
         return representation
 
 
+def _collapse_literal_pipe_runs(match: re.Match) -> str:
+    """
+    Decide whether a run of "|" characters (with any surrounding/interspersed
+    whitespace) should act as an OR operator or as a literal separator.
+
+    A pipe run is only treated as an OR operator when it is NOT surrounded by
+    whitespace on both sides, e.g. "a|b" or "a| b" remain OR operators, but
+    "a | b" (whitespace on both sides) does not. This is needed because many
+    indexed names literally contain " | ", e.g. "Metropolian kirjasto |
+    Myllypuro". Without this, such a query would be split into an OR search
+    ("Metropolian kirjasto" OR "myllypuro"), losing the AND relationship
+    between the words and matching unrelated units, e.g. other "Metropolian
+    kirjasto | <other location>" units.
+    """
+    separator = match.group(0)
+    if separator[:1].isspace() and separator[-1:].isspace():
+        return " "
+    return separator
+
+
 def build_search_query(query: str):
     result = ""
     query = query.strip(" |&,")
     query = query.replace("\\", "\\\\")
+    query = re.sub(r"(?:\s*\|+\s*)+", _collapse_literal_pipe_runs, query)
     or_operands = re.split(r"(?:\s*\|+\s*)+", query)
 
     for or_operand in or_operands:
@@ -286,9 +307,11 @@ def build_search_query(query: str):
             location=OpenApiParameter.QUERY,
             description="The query string used for searching. Searches the"
             " search_columns for the given models. Commas "
-            "between words are interpreted as 'and' operator. Words ending with the '|'"
-            " sign are interpreted as 'or' "
-            "operator.",
+            "between words are interpreted as 'and' operator. A '|' sign that is not"
+            " surrounded by whitespace on both sides (e.g. 'a|b' or 'a| b') is"
+            " interpreted as an 'or' operator. A '|' surrounded by whitespace on both"
+            " sides (e.g. 'a | b') is treated as a literal separator, so names that"
+            " contain ' | ' can be searched for as-is.",
             required=False,
             type=str,
         ),

--- a/services/search/tests/test_api.py
+++ b/services/search/tests/test_api.py
@@ -249,20 +249,30 @@ def test_search_with_vertical_bar_in_query(api_client, units):
         ("a&&&&&&&&&&&&&b", "a:* & b:*"),
         ("a  , &&&&&&&,    &  ,, & & & & &&&&& , , ,,,,      b", "a:* & b:*"),
         # Two-operand expressions with OR operator
-        ("a | b", "a:* | b:*"),
-        ("a | b", "a:* | b:*"),
+        # A '|' with whitespace on both sides is treated as a literal
+        # separator (AND), not as an OR operator. This allows searching for
+        # names that literally contain " | ", e.g. "Metropolian kirjasto |
+        # Myllypuro", without the query being split into an OR search.
+        ("a | b", "a:* & b:*"),
+        ("a | b", "a:* & b:*"),
         ("a| b", "a:* | b:*"),
         ("a |b", "a:* | b:*"),
         ("a|b", "a:* | b:*"),
         ("a|||||||||||||b", "a:* | b:*"),
-        ("a ||| |||    ||  | ||| b", "a:* | b:*"),
+        ("a ||| |||    ||  | ||| b", "a:* & b:*"),
         # >=3 operands
-        ("a | b | c", "a:* | b:* | c:*"),
+        ("a | b | c", "a:* & b:* & c:*"),
         ("a, b, c", "a:* & b:* & c:*"),
         ("a & b c, d", "a:* & b:* & c:* & d:*"),
         # Mixed OR and AND operators
-        ("a, b | c, d", "a:* & b:* | c:* & d:*"),
+        ("a, b | c, d", "a:* & b:* & c:* & d:*"),
         ("a, &&& , & b || || |||| |c,,,, d", "a:* & b:* | c:* & d:*"),
+        # Real unit names that literally contain " | " should be treated as a
+        # single AND expression, not split into an OR search.
+        (
+            "Metropolian kirjasto | myllypuro",
+            "Metropolian:* & kirjasto:* & myllypuro:*",
+        ),
         # Expression with repeating single-quotes
         ("','','''',a,b'c,d''e,f'''g,','','''", "a:* & b'c:* & d''e:* & f'''g:*"),
         # Empty operands
@@ -271,7 +281,7 @@ def test_search_with_vertical_bar_in_query(api_client, units):
         ("  &  ", ""),
         (",", ""),
         ("  ,  ", ""),
-        ("a |   | b", "a:* | b:*"),
+        ("a |   | b", "a:* & b:*"),
         ("a &   & b", "a:* & b:*"),
         ("a,   ,b", "a:* & b:*"),
         ("   | a", "a:*"),
@@ -311,10 +321,8 @@ def test_search_input_and_operator(api_client, units, query):
     "query",
     [
         "terveysasema|museo",
-        "terveysasema | museo",
         "terveysasema |museo",
         "terveysasema| museo",
-        "      terveysasema     |      museo  ",
         "terveysasema||museo",
         "terveysasema|||||||||museo",
         "|||terveysasema|museo||",
@@ -328,6 +336,29 @@ def test_search_input_or_operator(api_client, units, query):
     assert len(response.json()["results"]) == 2
     assert response.json()["results"][0]["name"]["fi"] == "Terveysasema"
     assert response.json()["results"][1]["name"]["fi"] == "Biologinen museo"
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "Biologinen | museo",
+        "      Biologinen     |      museo  ",
+    ],
+)
+@pytest.mark.django_db
+def test_search_input_pipe_surrounded_by_spaces_is_literal(api_client, units, query):
+    """
+    A '|' surrounded by whitespace on both sides is treated as a literal
+    separator (i.e. an 'and' operator), not as an 'or' operator. This allows
+    searching for names that literally contain " | ", e.g. "Metropolian
+    kirjasto | Myllypuro", without the query being split into an unrelated
+    'or' search.
+    """
+    url = reverse("search")
+    response = api_client.get(url, {"q": query, "type": "unit"})
+    assert response.status_code == 200
+    assert len(response.json()["results"]) == 1
+    assert response.json()["results"][0]["name"]["fi"] == "Biologinen museo"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Unit names like "Metropolian kirjasto | Myllypuro" contain a literal " | " separator. The search query builder always split on '|' as an OR operator, breaking the AND relationship between words and matching unrelated units (e.g. other "Metropolian kirjasto | <location>" units).

Now '|' only acts as an OR operator when it is not surrounded by whitespace on both sides (e.g. 'a|b', 'a| b' remain OR), while 'a | b' is treated as a literal/AND separator.

Refs: [PL-270](https://helsinkisolutionoffice.atlassian.net/browse/PL-270)

[PL-270]: https://helsinkisolutionoffice.atlassian.net/browse/PL-270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved search handling for names and phrases containing pipes surrounded by spaces.
  - Prevented literal separators such as “A | B” from being incorrectly interpreted as OR queries.
  - Improved handling of repeated and whitespace-padded separators.
  - Updated search behavior to return combined results for these queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->